### PR TITLE
Committee Note modifications

### DIFF
--- a/org.oasis.committeeNote.pdf/PDFTransformParameters.xml
+++ b/org.oasis.committeeNote.pdf/PDFTransformParameters.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<parameters>
+  <param name="args.input" expression="${args.input}"/>
+</parameters>

--- a/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-basic-settings.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-basic-settings.xsl
@@ -5,6 +5,12 @@
                 version="2.0"
                 exclude-result-prefixes="xs">
 
+ <!-- Thomas: Extract the base filename from args.input. 06dec17  -->
+  <xsl:param name="args.input"/>
+  <!-- Thomas: use regex to strip off the directory portion of the filename and to
+       remove the .ditamap file extension. 06dec17-->
+  <xsl:variable name="inputfile.basename" select="replace($args.input, '.+[\\/](.+)?.ditamap', '$1')"/>
+
  <!-- ===================== CHANGE LOG ================================ -->
  <!--                                                                   -->
  <!-- 5 Sept 2015: Eberlein, added change log.                          -->

--- a/org.oasis.committeeNote.pdf/cfg/fo/xsl/oasis-cn-footers.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/xsl/oasis-cn-footers.xsl
@@ -25,12 +25,6 @@
   />
  </xsl:variable>
  
- <xsl:variable name="specLevel"
-  select="
-  /*[contains(@class, ' bookmap/bookmap ')]/*
-  /*[contains(@class, ' bookmap/booktitle ')]
-  /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationLevel']"/>
- 
  <xsl:variable name="specSubtitle1"
   select="
   /*[contains(@class, ' bookmap/bookmap ')]/*
@@ -43,33 +37,6 @@
   /*[contains(@class, ' bookmap/booktitle ')]
   /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationSubtitle2']"/>
  
- <xsl:variable name="specPrefix"
-  select="
-  /*[contains(@class, ' bookmap/bookmap ')]/*
-  /*[contains(@class, ' bookmap/booktitle')]
-  /*[contains(@class, ' bookmap/booktitlealt ')][matches(@outputclass, 'specificationPrefix')]"/>
- 
- <xsl:variable name="specScope"
-  select="
-  /*[contains(@class, ' bookmap/bookmap ')]/*
-  /*[contains(@class, ' bookmap/booktitle')]
-  /*[contains(@class, ' bookmap/booktitlealt ')][matches(@outputclass, 'specificationScope')]"/>
- 
- <xsl:variable name="specVersion"
-  select="
-  /*[contains(@class, ' bookmap/bookmap ')]/*
-  /*[contains(@class, ' bookmap/bookmeta')]
-  /*[contains(@class, ' topic/prodinfo ')]
-  /*[contains(@class, ' topic/vrmlist ')]
-  /*[contains(@class, ' topic/vrm ')]/@version"/> 
- 
- <xsl:variable name="cnVersion"
-  select="
-   /*[contains(@class, ' bookmap/bookmap ')]/*
-   /*[contains(@class, ' bookmap/bookmeta')]
-   /*[contains(@class, ' bookmap/bookid ')]
-   /*[contains(@class, ' bookmap/edition ')]"/>
-
  <!-- VARIABLES: FOOTERS -->
  
  <!-- Variable: Approval date --> 
@@ -121,24 +88,6 @@
   <xsl:call-template name="getVariable">
    <xsl:with-param name="id" select="'Work product track'" />
   </xsl:call-template>
- </xsl:variable>
- 
- <!-- Variable: Work product metadata -->   
- <xsl:variable name="ditaversion">
-  <xsl:text>dita-</xsl:text>
-  <xsl:value-of select="$specVersion"/>
-  <xsl:text>-</xsl:text>
-  <xsl:value-of select="$specScope"/>
-  <xsl:text>-v</xsl:text>
-  <xsl:value-of select="$cnVersion"/>
-  <xsl:text>-</xsl:text>
-  <xsl:choose>
-   <xsl:when test="($specLevel castable as xs:double) and number($specLevel) > 0">
-    <xsl:value-of select="$specPrefix"/>
-    <xsl:number value="number($specLevel)" format="01"/>
-   </xsl:when>
-   <xsl:otherwise>spec</xsl:otherwise>
-  </xsl:choose>
  </xsl:variable>
  
  <!-- Variable: Work product status --> 

--- a/org.oasis.committeeNote.pdf/cfg/fo/xsl/oasis-cn-static-content.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/xsl/oasis-cn-static-content.xsl
@@ -166,14 +166,14 @@
                         <fo:table-cell>
                             <!-- abbreviated document name -->
                             <fo:block xsl:use-attribute-sets="default_footer">
-                                <xsl:value-of select="$ditaversion"/>
+                                <xsl:value-of select="$inputfile.basename"/>
                             </fo:block>
                         </fo:table-cell>
                         <fo:table-cell>
                             <!-- Level of committee note -->
-                            <fo:block xsl:use-attribute-sets="default_footer" text-align="center">
+                            <!--<fo:block xsl:use-attribute-sets="default_footer" text-align="center">
                                 <xsl:value-of select="$cnLevel"/>
-                            </fo:block>
+                            </fo:block>-->
                         </fo:table-cell>
                         <fo:table-cell>
                             <!-- approval date -->

--- a/org.oasis.committeeNote.pdf/plugin.xml
+++ b/org.oasis.committeeNote.pdf/plugin.xml
@@ -1,10 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <plugin id="org.oasis.committeeNote.pdf">
-  <require plugin="org.dita.pdf2" />
-  <feature extension="dita.conductor.transtype.check" 
-               value="oasis-pdf-committeeNote"
-                type="txt"/>
-  <feature extension="dita.conductor.target.relative" 
-               value="build.xml"
-                type="file"/>
+    <require plugin="org.dita.pdf2"/>
+    <feature extension="dita.conductor.transtype.check" value="oasis-pdf-committeeNote" type="txt"/>
+    <feature extension="dita.conductor.target.relative" value="build.xml" type="file"/>
+    <feature extension="dita.conductor.pdf2.param" type="file" value="PDFTransformParameters.xml"/>
 </plugin>

--- a/org.oasis.spec.preprocnumbering/xsl/oasis-maplink.xsl
+++ b/org.oasis.spec.preprocnumbering/xsl/oasis-maplink.xsl
@@ -213,22 +213,19 @@
             The target of the HREF is a local DITA file
             The user has not specified locktitle to override the title -->
           <xsl:if test="not(($FINALOUTPUTTYPE = 'PDF' or $FINALOUTPUTTYPE = 'IDD') and (not(@scope) or @scope = 'local') and (not(@format) or @format = 'dita') and (not(@locktitle) or @locktitle = 'no'))">
-            <xsl:message>oasis-maplink.xsl: Flag1</xsl:message>
             <linktext class="- topic/linktext ">
               <xsl:choose>
                 <xsl:when
                   test="
                   *[contains(@class, ' map/topicmeta ')]
                   /processing-instruction()[name() = 'ditaot'][. = 'usertext']">
-                  <xsl:message>oasis-maplink.xsl: Flag2</xsl:message>
                   <!-- Do not add section number to hard-coded link text -->
                 </xsl:when>
                 <xsl:when
                   test="
                   *[contains(@class, ' map/topicmeta ')]
                   /*[contains(@class, ' topic/data ')][@name = 'topicid']
-                  /*[contains(@class, ' topic/data ')][@name = 'number']/@value">
-                  <xsl:message>oasis-maplink.xsl: Flag3</xsl:message><xsl:value-of
+                  /*[contains(@class, ' topic/data ')][@name = 'number']/@value"><xsl:value-of
                     select="
                     (*[contains(@class, ' map/topicmeta ')]
                     /*[contains(@class, ' topic/data ')][@name = 'topicid']
@@ -236,7 +233,6 @@
                   <xsl:text> </xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:message>oasis-maplink.xsl: Flag4</xsl:message>
                   <xsl:variable name="thishref" select="@href"/>
                   <xsl:if
                     test="

--- a/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
+++ b/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
@@ -9,7 +9,8 @@
                    generate-xhtml-footer,
                    xhtml.topics,
                    build_oasis_xhtml_coverpage,
-                   copy-css"
+                   copy-css,
+                   zip_oasis_output"
     name="dita2spec-xhtml" description="OASIS Specification XHTML transform">
     <echoproperties/>
   </target>
@@ -78,5 +79,15 @@
       <param name="part-number" expression="${args.oasis.bookmeta.part-number}"/>
       <param name="spec-release-type" expression="${args.oasis.bookmeta.spec-release-type}"/>
     </xslt>
+  </target>
+  
+  <target name="zip_oasis_output" description="Zip HTML output">
+    <property name="args.oasis.xhtmlzip.filename" value="${outputFile.base}-html.zip"/>
+    <delete file="${dita.output.dir}${file.separator}${args.oasis.xhtmlzip.filename}"
+      failonerror="false"/>
+    <zip destfile="${dita.output.dir}${file.separator}${args.oasis.xhtmlzip.filename}"
+      basedir="${dita.output.dir}"
+      excludes="dita.list, dita.xml.properties, index.html, *.log, v${args.oasis.bookmeta.version-id}/"
+    />
   </target>
 </project>


### PR DESCRIPTION
1. Derive file basename in the PDF footer from args.input
2. Remove the stage name from over the copyright in the PDF footer
3. Remove debug code from org.oasis.committeeNote.xhtml XSLT
4. Add a .zip target to the org.oasis.committeeNote.xhtml ant script