### PR TITLE
Remove debug line, fix cascaded metadata

### DIFF
--- a/org.oasis.committeeNote.xhtml/xsl/oasis-cn-dita2htmlImpl.xsl
+++ b/org.oasis.committeeNote.xhtml/xsl/oasis-cn-dita2htmlImpl.xsl
@@ -10,6 +10,35 @@
   xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
   xmlns:oa-cn="org.oasis.committeenote" exclude-result-prefixes="xs dita-ot dita2html ditamsg">
 
+  <!-- Author, VRM, prodname templates are here to work around DITA OT issue
+       where metadata cascades (as a copy) to every topic, but then the single 
+       chunked result file puts all of those copies into the result. 
+       Overrides here ensure only one copy of duplicate metadata goes into metadata. --> 
+  <xsl:key name="authors" match="*[contains(@class,' topic/author ')]" use="."/>
+  <xsl:key name="vrms" match="*[contains(@class,' topic/vrm ')]" use="@version"/>
+  <xsl:key name="prodnames" match="*[contains(@class,' topic/prodname ')]" use="."/>
+  <xsl:template match="*[contains(@class,' topic/prodname ')]" mode="gen-metadata">
+    <xsl:choose>
+      <xsl:when test="normalize-space(.)=''"/>
+      <xsl:when test="generate-id(key('prodnames',.)[1])!=generate-id(.)"/>
+      <xsl:otherwise><xsl:next-match/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' topic/vrm ')]/@version" mode="gen-metadata">
+    <xsl:choose>
+      <xsl:when test="normalize-space(.)=''"/>
+      <xsl:when test="generate-id(key('vrms',.)[1])!=generate-id(parent::*)"/>
+      <xsl:otherwise><xsl:next-match/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' topic/author ')]" mode="gen-metadata">
+    <xsl:choose>
+      <xsl:when test="normalize-space(.)=''"/>
+      <xsl:when test="generate-id(key('authors',.)[1])!=generate-id(.)"/>
+      <xsl:otherwise><xsl:next-match/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <!-- child topics get a div wrapper and fall through -->
   <xsl:template match="*[contains(@class, ' topic/topic ')]" mode="child.topic" name="child.topic">
     <xsl:param name="nestlevel" as="xs:integer">

--- a/org.oasis.spec.preprocnumbering/xsl/oasis-mappull.xsl
+++ b/org.oasis.spec.preprocnumbering/xsl/oasis-mappull.xsl
@@ -25,12 +25,12 @@
     <xsl:copy>
       <xsl:apply-templates select="* | @* | comment() | processing-instruction() | text()"/>
     </xsl:copy>
-    <xsl:result-document href="file:/C:/Users/bob/Desktop/counting.xml" method="xml" indent="yes">
+    <!--<xsl:result-document href="file:/C:/Users/bob/Desktop/counting.xml" method="xml" indent="yes">
       <xsl:copy-of select="$counting-map"/>
     </xsl:result-document>
     <xsl:result-document href="file:/C:/Users/bob/Desktop/numbered.xml" method="xml" indent="yes">
       <xsl:copy-of select="$numbered-map"/>
-    </xsl:result-document>
+    </xsl:result-document>-->
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="build-counting-map">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Removes debug code that expected a specific desktop path; adds a workaround to prevent duplicate metadata from showing up in XHTML.