### PR TITLE
Fix broken footer problem for xhtml

### DIFF
--- a/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
+++ b/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
@@ -53,15 +53,16 @@
          the output directory below. -->
     <property name="oasis.generated.ftr"
       value="${dita.temp.dir}${file.separator}generated-spec-ftr.xml"/>
-    <makeurl file="${dita.temp.dir}${file.separator}generated-spec-ftr.xml" property="args.ftr"
-      validate="no"/>
-    <echo>Footer is creating links to: ${args.oasis.footerlinks}</echo>
+    <property name="args.ftr"
+      value="${dita.temp.dir}${file.separator}generated-spec-ftr.xml"/>
+    <!--<makeurl file="${dita.temp.dir}${file.separator}generated-spec-ftr.xml" property="args.ftr"
+      validate="no"/>-->
     <xslt processor="trax" basedir="${dita.temp.dir}"
       in="${dita.temp.dir}${file.separator}${user.input.file}" out="${oasis.generated.ftr}"
       classpathref="dost.class.path"
       style="${dita.plugin.org.oasis.spec.xhtml.dir}${file.separator}xsl${file.separator}oasis_footer.xsl">
       <param name="COVERPAGE" expression="${outputFile.base}${args.outext}"/>
-      <param name="LINKS" expression="${args.oasis.footerlinks}"/>
+      <param name="LINKS" expression="${args.oasis.footerlinks}" if="args.oasis.footerlinks"/>
       <param name="outputfilebasename" expression="${outputFile.base}"/>
     </xslt>
   </target>

--- a/org.oasis.spec.xhtml/xsl/oasis_footer.xsl
+++ b/org.oasis.spec.xhtml/xsl/oasis_footer.xsl
@@ -19,7 +19,7 @@
         <xsl:text>Return to </xsl:text>
         <a>
           <xsl:attribute name="href">
-            <xsl:choose>
+            <!--<xsl:choose>
               <xsl:when test="$LINKS = 'online'">
                 <xsl:value-of
                   select="
@@ -28,10 +28,10 @@
                     /*[@format = 'html']/@href"
                 />
               </xsl:when>
-              <xsl:otherwise>
+              <xsl:otherwise>-->
                 <xsl:value-of select="$COVERPAGE"/>
-              </xsl:otherwise>
-            </xsl:choose>
+              <!--</xsl:otherwise>
+            </xsl:choose>-->
           </xsl:attribute>
           <xsl:text>main page</xsl:text>
         </a>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Currently getting a failure in the XHTML build because the `args.ftr` parameter is set to a URL rather than to the file name. DITA-OT seems to want the file name, so I changed `<makeurl>` into `<property>` and the file was picked up properly.

Also updated so that it always links to the HTML cover page rather than making that an option - not sure exactly what the other option was intended to do but it resulted in an empty link for the "return to main page" section.