### PR TITLE
Fix cover footer for xhtml, all footers for htmlhelp

### DIFF
--- a/org.oasis.spec.htmlhelp/build_dita2spec-htmlhelp.xml
+++ b/org.oasis.spec.htmlhelp/build_dita2spec-htmlhelp.xml
@@ -10,6 +10,7 @@
     use-init.envhhcdir,
     use-init.hhcdir,
     preprocess,
+    generate-xhtml-footer,
     xhtml.topics,
     build_oasis_xhtml_coverpage,
     copy-css">

--- a/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
+++ b/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
@@ -55,8 +55,8 @@
       value="${dita.temp.dir}${file.separator}generated-spec-ftr.xml"/>
     <property name="args.ftr"
       value="${dita.temp.dir}${file.separator}generated-spec-ftr.xml"/>
-    <!--<makeurl file="${dita.temp.dir}${file.separator}generated-spec-ftr.xml" property="args.ftr"
-      validate="no"/>-->
+    <makeurl file="${dita.temp.dir}${file.separator}generated-spec-ftr.xml" property="args.ftr.url"
+      validate="no"/>
     <xslt processor="trax" basedir="${dita.temp.dir}"
       in="${dita.temp.dir}${file.separator}${user.input.file}" out="${oasis.generated.ftr}"
       classpathref="dost.class.path"
@@ -78,7 +78,7 @@
       <!-- Tagsmiths: Eliminated DITAEXT parameter. Now using XSLT 2.0 replace() function to capture basename. -04oct13-->
       <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
       <param name="FORMAT" expression="xhtml"/>
-      <param name="FOOTER" expression="${args.ftr}"/>
+      <param name="FOOTER" expression="${args.ftr.url}"/>
       <param name="version-id" expression="${args.oasis.bookmeta.version-id}"/>
       <param name="errata-num" expression="${args.oasis.bookmeta.errata-num}"/>
       <param name="stage-abbrev" expression="${args.oasis.bookmeta.stage-abbrev}"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes the following error in CHM output:
```
java.io.FileNotFoundException: C:\DITA-OT-2.5.4-OASIS\plugins\org.oasis.spec.xhtml\xsl\${args.ftr} (The system cannot find the file specified) Cause: java.io.FileNotFoundException: C:\DITA-OT-2.5.4-OASIS\plugins\org.oasis.spec.xhtml\xsl\${args.ftr} (The system cannot find the file specified)
```

Was caused by not running the Ant target to generate the footer file for HTML Help.

Also fixes this error for XHTML:
```
[xslt] C:\DITA-OT-2.5.4-OASIS\plugins\org.oasis.spec.xhtml\xsl\oasis_coverpage.xsl:257: Error! Exception thrown by URIResolver Cause: java.lang.reflect.InvocationTargetEx
```

Was caused by using `args.ftr` property in a way that required a file path (in one location) and also in a way that required a URL (in another location). Earlier fix that let `args.ftr` work as a file path caused this error where URL was required.