### PR TITLE
Ensure FTR is generated properly for parts 1/2/3 in CHM

### DIFF
--- a/org.oasis.spec.htmlhelp/build_dita2spec-htmlhelp.xml
+++ b/org.oasis.spec.htmlhelp/build_dita2spec-htmlhelp.xml
@@ -10,6 +10,7 @@
     use-init.envhhcdir,
     use-init.hhcdir,
     preprocess,
+    pub-meta-to-ant-props,
     generate-xhtml-footer,
     xhtml.topics,
     build_oasis_xhtml_coverpage,


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes an issue where `outputFile.base` was not set for parts 1, 2, and 3 before trying to generate footer.