### PR TITLE
Do not fail build when outdir is missing

### DIFF
--- a/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
+++ b/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
@@ -41,7 +41,7 @@
       </not>
     </condition>
     
-    <delete>
+    <delete failonerror="false">
       <fileset dir="${output.dir}">
         <exclude name="**/*.zip"/>
       </fileset>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

When initially setting up the plugins for first use, if I don't already have an output directory specified, building the specification map to format `spec-xhtml` results in an immediate build failure. This happens because it's trying to clear the output directory, but the output directory doesn't exist. I got around this a few times by creating the output directory and re-running the build.

Setting `failonerror="false"` makes this a bit friendlier by continuing and creating the empty output directory.