### PR TITLE
Add code to allow the org.oasis.specification.pubmeta and org.oasis.spec.pdf plugins to run in dita-ot-3.x

### DIFF
--- a/org.oasis.spec.pdf/xsl/fo/spec_front-matter.xsl
+++ b/org.oasis.spec.pdf/xsl/fo/spec_front-matter.xsl
@@ -116,11 +116,23 @@
 
   <xsl:template match="*[@rev != '']" mode="revmarkup">
     <fo:inline xsl:use-attribute-sets="revised">
+      <!-- Tagsmiths: Flagging in mainbooktitle not supported in dita-ot-2.x. 22jun18 -->
       <xsl:text>►</xsl:text>
-      <xsl:variable name="trim-buffer" select="."/>
+      <xsl:variable name="trim-buffer">
+        <!-- Tagsmiths: As of 22jun18, dita-ot-3.x produces two redundant instances of ditaval-startprop and
+             ditaval-endprop in this context. Suppress flagging entirely in this context and let the workaround used for dita-ot-2.x
+             handle the revision marking. -->
+        <xsl:apply-templates mode="suppress-flagging"/>
+      </xsl:variable>
       <xsl:value-of select="normalize-space($trim-buffer)"/>
       <xsl:text>◄</xsl:text>
     </fo:inline>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" mode="suppress-flagging" priority="100"/>
+  
+  <xsl:template match="*|text()" mode="suppress-flagging">
+    <xsl:apply-templates select="."/>
   </xsl:template>
 
   <xsl:template name="spdf:cover-image">
@@ -147,7 +159,6 @@
         /bookmap/opentopic:map/frontmatter/*[contains(@class, ' bookmap/notices ')] |
         /bookmap/opentopic:map/frontmatter/*[contains(@class, ' bookmap/notices ')]//topicref">
       <xsl:value-of select="concat('~', @id, '~')"/>
-      <!--<xsl:message>spec_front-matter.xsl: </xsl:message>-->
     </xsl:for-each>
   </xsl:variable>
 

--- a/org.oasis.specification.pubmeta/build-pubmeta.xml
+++ b/org.oasis.specification.pubmeta/build-pubmeta.xml
@@ -18,10 +18,13 @@
     <!-- Tagsmiths: The pub-meta-to-ant-props target pulls publication-specific information out of the
          root map and makes that information available in the build environment as ant propterties.
          All args.oasis.bookmeta.* properties come from this target. -02oct13 -->
+    <!-- Tagsmiths: Beginning in dita-ot-3.x args.input and dita.input.file no longer have the same
+         filename. Changed @in to point at .job.xml so that dita.input.file can be looked up.-->
     <xslt processor="trax" basedir="${dita.temp.dir}" destdir="${dita.temp.dir}"
-      in="${dita.temp.dir}${file.separator}${dita.input.filename}"
+      in="${dita.temp.dir}${file.separator}.job.xml"
       out="${dita.temp.dir}${file.separator}pubMetadataProps.xml"
-      style="${dita.plugin.org.oasis.specification.pubmeta.dir}${file.separator}xsl${file.separator}pubMetaToAntProps.xsl"> </xslt>
+      style="${dita.plugin.org.oasis.specification.pubmeta.dir}${file.separator}xsl${file.separator}pubMetaToAntProps.xsl"> <param name="dita.temp.dir" expression="${dita.temp.dir}"/>
+    </xslt>
     <xmlproperty file="${dita.temp.dir}${file.separator}pubMetadataProps.xml"/>
     <property name="outputFile.base" value="${args.oasis.bookmeta.outputfilebasename}"/>
   </target>

--- a/org.oasis.specification.pubmeta/xsl/pubMetaToAntProps.xsl
+++ b/org.oasis.specification.pubmeta/xsl/pubMetaToAntProps.xsl
@@ -5,50 +5,30 @@
 
   <xsl:output method="xml" indent="yes"/>
 
-  <xsl:variable name="wp-abbrev">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'wp-abbrev'])"/>
-  </xsl:variable>
-  <xsl:variable name="version-id">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'version-id'])"/>
-  </xsl:variable>
-  <xsl:variable name="errata-num">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'errata-num'])"/>
-  </xsl:variable>
-  <xsl:variable name="stage-abbrev">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'stage-abbrev'])"/>
-  </xsl:variable>
-  <xsl:variable name="prev-stage-abbrev">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'prev-stage-abbrev'])"/>
-  </xsl:variable>
-  <xsl:variable name="revision-num">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'revision-num'])"/>
-  </xsl:variable>
-  <xsl:variable name="prev-revision-num">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'prev-revision-num'])"/>
-  </xsl:variable>
+  <xsl:param name="dita.temp.dir"/>
+
+  <xsl:variable name="user.input.file.name" select="replace(concat('file:///', $dita.temp.dir, '/', /job/property[@name='user.input.file']/string),'\\', '/')"/>
+  <xsl:variable name="user.input.file" select="doc($user.input.file.name)"/>
+  <xsl:variable name="wp-abbrev" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'wp-abbrev'])"/>
+  <xsl:variable name="version-id" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'version-id'])"
+    />
+  <xsl:variable name="errata-num" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'errata-num'])"/>
+  <xsl:variable name="stage-abbrev" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'stage-abbrev'])"/>
+  <xsl:variable name="prev-stage-abbrev" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'prev-stage-abbrev'])"/>
+  <xsl:variable name="revision-num" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'revision-num'])"/>
+  <xsl:variable name="prev-revision-num" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'prev-revision-num'])"
+    />
   <xsl:variable name="part-number">
     <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'part-number'])"/>
+      select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'part-number'])"/>
   </xsl:variable>
-  <xsl:variable name="abbrev-part-name">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'abbrev-part-name'])"/>
-  </xsl:variable>
-  <xsl:variable name="errata-artifact-type">
-    <!-- Notice that this select attribute uses a general //keydef XPath selector instead
-         of the /bookmap/frontmatter/topichead/keydef selector. This was done so that you
+  <xsl:variable name="abbrev-part-name" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'abbrev-part-name'])"/>
+  <!-- Notice that this select attribute uses a general //keydef XPath selector instead
+         of the $user.input.file/bookmap/frontmatter/topichead/keydef selector. This was done so that you
          can override this key in the errata summary bookmap by defining it directly in the
          bookmap before the part-specify key definition ditamap gets read.
     -->
-    <xsl:value-of select="normalize-space((//keydef[@keys = 'errata-artifact-type'])[1])"/>
-  </xsl:variable>
+  <xsl:variable name="errata-artifact-type" select="normalize-space((//keydef[@keys = 'errata-artifact-type'])[1])"/>
   <!-- This is needed for the errata summary document cover. Specifically, it's here to
        to trigger the correct file name construction for parts 0 - 3 in the Additional
        artifacts section.-->
@@ -62,26 +42,17 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <xsl:variable name="oasis-dita-uri-base">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'oasis-dita-uri-base'])"
+  <xsl:variable name="oasis-dita-uri-base" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'oasis-dita-uri-base'])"
     />
-  </xsl:variable>
   <xsl:variable name="outputbasefilename">
+    <!-- Tagsmiths: For some reason, Saxon doesn't like evaulating a local function from variable/@select. 21jun18 -->
     <xsl:value-of
       select="spec:getBaseFilename($errata-num, $errata-artifact-type, $stage-abbrev, $revision-num, $part-number, $abbrev-part-name)"
     />
   </xsl:variable>
-  <xsl:variable name="grammarfilename">
-    <xsl:value-of select="replace($outputbasefilename, '-complete', '-complete-grammars.zip')"/>
-  </xsl:variable>
-  <xsl:variable name="sourcefilename">
-    <xsl:value-of select="concat($outputbasefilename, '-dita.zip')"/>
-  </xsl:variable>
-  <xsl:variable name="approval-date">
-    <xsl:value-of
-      select="normalize-space(/bookmap/frontmatter/topichead/keydef[@keys = 'approval-date'])"/>
-  </xsl:variable>
+  <xsl:variable name="grammarfilename" select="replace($outputbasefilename, '-complete', '-complete-grammars.zip')"/>
+  <xsl:variable name="sourcefilename" select="concat($outputbasefilename, '-dita.zip')"/>
+  <xsl:variable name="approval-date" select="normalize-space($user.input.file/bookmap/frontmatter/topichead/keydef[@keys = 'approval-date'])"/>
   <xsl:variable name="spec-release-type">
     <xsl:choose>
       <xsl:when test="$stage-abbrev = 'csd'">


### PR DESCRIPTION
Previous code for publication metadata collection relied upon the filename in ant property args.input.dita and the job property user.input.file being the same. Since dita-ot-3.x this is no longer the case.  org.oasis.specification.pubmeta now accommodates that difference.

dita-ot-3.x adds flagging support for mainbooktitle. Unfortunately, the code for that produces redundant flagging. The changes in spec_front-matter.xsl suppress dita-ot-3.x flagging support in mainbooktitle.

