### PR TITLE
Continued tweaks to match OASIS template

### DIFF
--- a/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-commons-attr.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-commons-attr.xsl
@@ -8,7 +8,7 @@
 <!-- 05 Oct 2015 KJE: Increased font size for section titles           -->
 <!-- 30 Jan 2019 KJE: Changed $default-title-color as required for     -->
 <!--                  OASIS rebranding                                 -->
-<!--                                                                   -->
+<!-- 06 Mar 2019 KJE: Changed base-font to 10 pt                       -->
 <!-- ================================================================= -->  
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -22,7 +22,7 @@
     <!-- BASIC FONT -->
     <xsl:attribute-set name="__fo__root" use-attribute-sets="base-font">
         <xsl:attribute name="font-family">sans-serif</xsl:attribute>
-        <xsl:attribute name="font-size">11pt</xsl:attribute>
+        <xsl:attribute name="font-size">10pt</xsl:attribute>
         <xsl:attribute name="id">fo-root-do-not-change</xsl:attribute>
     </xsl:attribute-set>
    

--- a/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-cover-attr.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-cover-attr.xsl
@@ -5,7 +5,7 @@
 <!-- 27 Aug 2015 KJE: Removed indentation from cover page              -->
 <!-- 05 Sep 2015 KJE: Consolidated attribute sets. Added attribute     -->
 <!--                  sets for the left flow on the cover.             -->
-<!-- 01 Feb 2016 KJE: Implemented OASIS redesign for committee note:   -->
+<!-- 01 Feb 2019 KJE: Implemented OASIS redesign for committee note:   -->
 <!--                  removed attribute sets for cover page sidebar;   -->
 <!--                  added attribute set for cover page header        -->
 <!--                                                                   -->

--- a/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-tables-attr.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-tables-attr.xsl
@@ -7,6 +7,7 @@
 <!-- 21 Sep 2015 KJE: Added override for @keycol in header row         -->
 <!-- 08 Oct 2015  BT: Added strow.stentry override                     -->
 <!-- 01 Feb 2019 KJE: Changed color for table headers                  -->
+<!-- 06 Mar 2019 KJE: Changed font size for simple table cells         -->
 <!--                                                                   -->
 <!-- ================================================================= --> 
 
@@ -16,7 +17,7 @@
    
   <!-- VARIABLES -->
   <xsl:variable name="default-table-header-color">#edf1f8</xsl:variable>
-  
+  <xsl:variable name="default-table-font-size">9pt</xsl:variable>
   <!-- DEFINITION LISTS -->
   <xsl:attribute-set name="dl"/>
   
@@ -34,6 +35,9 @@
   <xsl:attribute-set name="sthead.stentry">
     <xsl:attribute name="background-color">
       <xsl:value-of select="$default-table-header-color"/>
+    </xsl:attribute>
+    <xsl:attribute name="font-size">
+      <xsl:value-of select="$default-table-font-size"/>
     </xsl:attribute>
   </xsl:attribute-set>
   
@@ -54,6 +58,9 @@
     <xsl:attribute name="border-before-style">solid</xsl:attribute>
     <xsl:attribute name="border-before-width">1pt</xsl:attribute>
     <xsl:attribute name="border-before-width.conditionality">retain</xsl:attribute>
+    <xsl:attribute name="font-size">
+      <xsl:value-of select="$default-table-font-size"/>
+    </xsl:attribute>
   </xsl:attribute-set>
   
 </xsl:stylesheet>

--- a/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-toc-attr.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-toc-attr.xsl
@@ -3,9 +3,9 @@
 <!-- ===================== CHANGE LOG ================================ -->
 <!--                                                                   -->
 <!-- 05 Sep 2015 KJE: Added change log. Added $toc.toc-indent.         -->
-<!-- 05 Sep 2015 ARH: Removed horizontal-rule from __toc__header       -->
+<!-- 03 Mar 2019 ARH: Removed horizontal-rule from __toc__header       -->
 <!--                  to accommodate OASIS rebranding                  -->
-<!--                                                                   -->
+<!-- 06 Mar 2019 KJE: Changed font-size to 10 pt                       -->
 <!-- ================================================================= --> 
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -17,7 +17,7 @@
     
     <!-- Common formatting for many items in the TOC -->  
     <xsl:attribute-set name="default-TOC">
-        <xsl:attribute name="font-size">11pt</xsl:attribute>
+        <xsl:attribute name="font-size">10pt</xsl:attribute>
         <xsl:attribute name="font-weight">normal</xsl:attribute>
         <xsl:attribute name="padding-top">0pt</xsl:attribute>
     </xsl:attribute-set>
@@ -25,6 +25,7 @@
     <!-- Controls formatting of the auto-generated title on first page of TOC -->
     <xsl:attribute-set name="__toc__header" use-attribute-sets="common.title">
         <xsl:attribute name="font-size">18pt</xsl:attribute>
+        <xsl:attribute name="font-weight">bold</xsl:attribute>
         <xsl:attribute name="margin-top">0pt</xsl:attribute>
         <xsl:attribute name="margin-bottom">8.4pt</xsl:attribute>
         <xsl:attribute name="padding-top">2pt</xsl:attribute>

--- a/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-xml-domain-attr.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/attrs/oasis-cn-xml-domain-attr.xsl
@@ -3,6 +3,7 @@
 <!-- ===================== CHANGE LOG ================================ -->
 <!--                                                                   -->
 <!-- 29 Oct 2016 KJE: Initial creation.                                -->
+<!-- 06 Mar 2019 KJE: Changed font-size to 9 pt                        -->
 <!-- ================================================================= -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -11,12 +12,12 @@
   
   <xsl:attribute-set name="xmlelement">
     <xsl:attribute name="font-family">monospace</xsl:attribute>
-    <xsl:attribute name="font-size">10pt</xsl:attribute>
+    <xsl:attribute name="font-size">9pt</xsl:attribute>
   </xsl:attribute-set>
   
   <xsl:attribute-set name="xmlatt">
     <xsl:attribute name="font-family">monospace</xsl:attribute>
-    <xsl:attribute name="font-size">10pt</xsl:attribute>
+    <xsl:attribute name="font-size">9pt</xsl:attribute>
   </xsl:attribute-set>
     
 </xsl:stylesheet>

--- a/org.oasis.committeeNote.pdf/cfg/fo/oasis-cn-font-mappings.xml
+++ b/org.oasis.committeeNote.pdf/cfg/fo/oasis-cn-font-mappings.xml
@@ -5,6 +5,8 @@
 <!-- 05 Sep 2015 KJE: Added change log.                                -->
 <!-- 30 Jan 2019 KJE: Changed serif to "Arial"                         -->
 <!-- 20 Feb 2019 KJE: Changed serif and sans to "Liberation Sans"      -->
+<!-- 03 Mar 2019 KJE: Changed monospace to "Liberation Mono"           -->
+<!--                                                                   -->
 <!-- ================================================================= --> 
 
 <font-mappings>
@@ -81,7 +83,7 @@
 
     <logical-font name="Monospaced">
       <physical-font char-set="default">
-        <font-face>Courier New, Courier</font-face>
+        <font-face>Liberation Mono</font-face>
       </physical-font>
       <physical-font char-set="Simplified Chinese">
         <font-face>AdobeSongStd-Light</font-face>

--- a/org.oasis.committeeNote.pdf/cfg/fo/xsl/oasis-cn-cover-notices.xsl
+++ b/org.oasis.committeeNote.pdf/cfg/fo/xsl/oasis-cn-cover-notices.xsl
@@ -5,6 +5,9 @@
 <!-- 05 Sep 2015 KJE: Added change log.                                -->
 <!-- 31 Jan 2016 KJE: Replaced call to deprecated template             -->
 <!-- 12 Jul 2016  BT: Changed xref from fo:inline to fo:basic-link     -->
+<!-- 06 Mar 2019 KJE: Removed indentation from <dd>; made <dt> bold    -->
+<!--                  and adding padding-top                           -->
+<!--                                                                   -->
 <!-- ================================================================= --> 
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
@@ -63,13 +66,15 @@
 
   <xsl:template match="*[contains(@class, ' topic/dt ')]" mode="cover">
     <fo:block>
+      <xsl:attribute name="font-weight">bold</xsl:attribute>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' topic/dd ')]" mode="cover">
     <fo:block>
-      <xsl:attribute name="margin-left">.15in</xsl:attribute>
+      <xsl:attribute name="margin-left">0in</xsl:attribute>      
+      <xsl:attribute name="padding-top">5pt</xsl:attribute>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>


### PR DESCRIPTION
* Corrected instances where font was 11 pts rather than 10 pt
* Corrected styling for "Citation format" content on cover page
* Reduced font size for inline monospaced text 
* Changed monospace font to "Liberation Mono"