### PR TITLE
Update integrator.xml

### DIFF
--- a/org.oasis.spec.pdf/integrator.xml
+++ b/org.oasis.spec.pdf/integrator.xml
@@ -13,4 +13,6 @@
         <property name="args.fo.include.rellinks" value="none"/>
     </target>
     <target depends="dita2spec-pdf.init, dita2pdf2" name="dita2spec-pdf"/>
+    <!-- Override preprocess2 dependency in pdf2 plugin, so pubmeta plugin will work -->
+    <target name="dita2pdf2" depends="dita2pdf2.init, build-init, preprocess, map2pdf2, topic2pdf2"/>
 </project>


### PR DESCRIPTION
DITA OT 2.5+ replaced the "preprocess" stage with "preprocess2" for monolithic output formats. "preprocess2" writes unique filenames to the temp folder, which breaks the pubmeta filter (pubmeta looks for the original map filename for additional processing). Submitting this as a temporary fix to allow TC spec builds with newer versions of the OT.