### PR TITLE
DRAFT: Generate PDF table of RFC clauses

### DIFF
--- a/org.oasis-open.pdf/cfg/fo/xsl/oasis-rfclist.xsl
+++ b/org.oasis-open.pdf/cfg/fo/xsl/oasis-rfclist.xsl
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xsl:stylesheet spdf:version="2.4.1"
+  exclude-result-prefixes="ditaarch opentopic spdf specrfc"
+  version="2.0"
+  xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  xmlns:spdf="org.oasis.spec.pdf"
+  xmlns:opentopic="http://www.idiominc.com/opentopic"
+  xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:specrfc="org.oasis.spec.pdf/rfc"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  
+  <xsl:key name="rfc-terms" match="*[@specrfc:container]" use="true()"/>
+   
+  <xsl:template match="*[contains(@class,' topic/data ')][@name='rfc-list']">
+    <xsl:if test="exists(key('rfc-terms',true())[not(ancestor::draft-comment or ancestor::required-cleanup)])">
+      <xsl:variable name="collected-rules-as-list" as="element()">
+        <ol class="- topic/ol ">
+          <xsl:for-each select="key('rfc-terms',true())[not(ancestor::draft-comment or ancestor::required-cleanup or ancestor::*[@specrfc:container])]">
+            <xsl:variable name="elname">
+              <xsl:choose>
+                <xsl:when test="contains(@class,' topic/ph ')">ph</xsl:when>
+                <xsl:when test="contains(@class,' topic/p ')">p</xsl:when>
+                <xsl:when test="contains(@class,' topic/div ')">div</xsl:when>
+                <xsl:when test="contains(@class,' topic/li ')">li</xsl:when>
+              </xsl:choose>
+              <!--<xsl:value-of select="name(ancestor::*[ or contains(@class,' topic/p ') or contains(@class,' topic/div ') or
+                contains(@class,' topic/li ')][1])"/>-->
+            </xsl:variable>
+            <li class="- topic/li ">
+              <xref class="- topic/xref " href="#{@id}">Conformance item:</xref>
+              <xsl:choose>
+                <xsl:when test="$elname='ph'"><p class="- topic/p "><xsl:apply-templates select="." mode="copy-normative-rule"/></p></xsl:when>
+                <xsl:when test="$elname='p'"><xsl:apply-templates select="." mode="copy-normative-rule"/></xsl:when>
+                <xsl:when test="$elname='li'"><p class="- topic/p "><xsl:apply-templates select="node()" mode="copy-normative-rule"/></p></xsl:when>
+                <xsl:when test="$elname='div'"><xsl:apply-templates select="." mode="copy-normative-rule"/></xsl:when>
+                <xsl:otherwise><xsl:message>Failed to copy in conformance item from <xsl:for-each select="ancestor-or-self::*"><xsl:value-of select="name()"/>/</xsl:for-each></xsl:message>Missing conformance item: <xsl:for-each select="ancestor-or-self::*"><xsl:value-of select="name()"/>/</xsl:for-each></xsl:otherwise>
+              </xsl:choose>
+            </li>
+          </xsl:for-each>
+        </ol>
+      </xsl:variable>
+      
+      <xsl:variable name="collected-rules-as-table" as="element()">
+        <simpletable relcolwidth="1* 7*" class="- topic/simpletable " outputclass="collected-rfc-rules" id="collected-rfc-rules-as-table" frame="all">
+          <sthead class="- topic/sthead ">
+            <stentry class="- topic/stentry ">Rule number</stentry>
+            <stentry class="- topic/stentry ">Conformance statement</stentry>
+          </sthead>
+          <xsl:for-each select="key('rfc-terms',true())[not(ancestor::draft-comment or ancestor::required-cleanup or ancestor::*[@specrfc:container])]">
+            <xsl:variable name="elname">
+              <xsl:choose>
+                <xsl:when test="contains(@class,' topic/ph ')">ph</xsl:when>
+                <xsl:when test="contains(@class,' topic/p ')">p</xsl:when>
+                <xsl:when test="contains(@class,' topic/div ')">div</xsl:when>
+                <xsl:when test="contains(@class,' topic/li ')">li</xsl:when>
+              </xsl:choose>
+              <!--<xsl:value-of select="name(ancestor::*[ or contains(@class,' topic/p ') or contains(@class,' topic/div ') or
+                contains(@class,' topic/li ')][1])"/>-->
+            </xsl:variable>
+            <strow class="- topic/strow ">
+              <stentry class="- topic/stentry " id="gen-rfc-item-{position()}"><xref class="- topic/xref " href="#{@id}">Rule <xsl:value-of select="position()"/></xref></stentry>
+              <stentry class="- topic/stentry ">
+                <xsl:choose>
+                  <xsl:when test="$elname='ph'"><xsl:apply-templates select="." mode="copy-normative-rule"/></xsl:when>
+                  <xsl:when test="$elname='p'"><xsl:apply-templates select="node()" mode="copy-normative-rule"/></xsl:when>
+                  <xsl:when test="$elname='li'"><xsl:apply-templates select="node()" mode="copy-normative-rule"/></xsl:when>
+                  <xsl:when test="$elname='div'"><xsl:apply-templates select="node()" mode="copy-normative-rule"/></xsl:when>
+                  <xsl:otherwise><xsl:message>Failed to copy in conformance item from <xsl:for-each select="ancestor-or-self::*"><xsl:value-of select="name()"/>/</xsl:for-each></xsl:message>Missing conformance item: <xsl:for-each select="ancestor-or-self::*"><xsl:value-of select="name()"/>/</xsl:for-each></xsl:otherwise>
+                </xsl:choose>
+              </stentry>
+            </strow>
+          </xsl:for-each>
+        </simpletable>
+      </xsl:variable>
+      
+      <xsl:apply-templates select="$collected-rules-as-table"/>
+    </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="@id" mode="copy-normative-rule"/>
+  <xsl:template match="*|@*|text()" mode="copy-normative-rule">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|*|text()" mode="copy-normative-rule"/>
+    </xsl:copy>
+  </xsl:template>
+  
+</xsl:stylesheet>

--- a/org.oasis-open.pdf/cfg/fo/xsl/oasis-spec-topic2fo-shell.xsl
+++ b/org.oasis-open.pdf/cfg/fo/xsl/oasis-spec-topic2fo-shell.xsl
@@ -15,6 +15,7 @@
     <xsl:import href="plugin:org.oasis-open.pdf:cfg/fo/xsl/oasis-spec-front-matter.xsl"/>
     <xsl:import href="plugin:org.oasis-open.pdf:cfg/fo/xsl/oasis-spec-footers.xsl"/>
     <xsl:import href="plugin:org.oasis-open.pdf:cfg/fo/attrs/oasis-spec-topic-attr.xsl"/>
+    <xsl:import href="plugin:org.oasis-open.pdf:cfg/fo/xsl/oasis-rfclist.xsl"/>
     
     <xsl:output method="xml" encoding="utf-8" indent="no"/>
 

--- a/org.oasis-open.pdf/plugin.xml
+++ b/org.oasis-open.pdf/plugin.xml
@@ -15,4 +15,5 @@
     <feature extension="dita.conductor.transtype.check" value="oasis-pdf-generic" type="txt"/>
     <feature extension="ant.import" value="build-oasis-pdf.xml" type="file"/>
     <feature extension="dita.conductor.pdf2.param" type="file" value="PDFTransformParameters.xml"/>
+    <feature extension="org.dita.pdf2.xsl.topicmerge" type="file" value="xsl/common/spec_topicmergeImpl.xsl"/>
 </plugin>

--- a/org.oasis-open.pdf/xsl/common/spec_topicmergeImpl.xsl
+++ b/org.oasis-open.pdf/xsl/common/spec_topicmergeImpl.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:specrfc="org.oasis.spec.pdf/rfc"
+    xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
+    xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+    exclude-result-prefixes="xs dita-ot specrfc">
+    
+    <xsl:template match="*[contains(@class,' topic/p ') or contains(@class,' topic/div ') or contains(@class,' topic/li ') or contains(@class,' topic/ph ')]
+        [descendant::*[contains(@class, ' topic/term ')][@outputclass = 'RFC-2119']]
+        [ancestor::*[contains(@class,' topic/topic ')]]
+        [not(ancestor::*[contains(@class,' topic/desc ') or contains(@class,' topic/related-links ')])]">
+        <xsl:param name="newid"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@*">
+                <xsl:with-param name="newid"/>
+            </xsl:apply-templates>
+            <xsl:attribute name="specrfc:container" select="'true'"/>
+            <xsl:if test="not(@id)"><xsl:attribute name="id" select="concat('rfc-genid-',generate-id(.))"/></xsl:if>
+            <xsl:apply-templates select="*|text()|processing-instruction()|comment()">
+                <xsl:with-param name="newid"/>
+            </xsl:apply-templates>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Current implementation:

- Matches `<data name="rfc-list">` in any topic. To get this to appear, need to add that to a topic (intent is to add it to an appendix topic).
- When found, generates a table including every RFC clause from the current document
- In this first draft, each rule is numbered sequentially as "Rule N"

Further work before this is complete:
- Each RFC number should be based on the topic number (for example: 2.4.3-a for the first rule in topic 2.4.3, 2.4.3-b for the second rule in topic 2.4.3, etc)
- Move topic numbering into a general function so that consistent numbering is used for all output formats, and so that we do not have to re-implement that numbering for both HTML and PDF
- Optionally include the topic title along with the rule for further context