### PR TITLE
Common plugin for OASIS output

### DIFF
--- a/org.oasis-open.common/oasis-common-build.xml
+++ b/org.oasis-open.common/oasis-common-build.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:if="ant:if" xmlns:unless="ant:unless" name="add-identifiers">
+
+	<target name="add-identifiers">
+		<pipeline message="Add IDs to blocks" taskname="add-identifiers">
+			<xslt basedir="${dita.temp.dir}"
+				style="${dita.plugin.org.oasis-open.common.dir}/xsl/add-identifiers.xsl">
+				<ditaFileset format="dita"/>
+				<xmlcatalog refid="dita.catalog"/>
+			</xslt>
+		</pipeline>
+	</target>
+	
+</project>

--- a/org.oasis-open.common/plugin.xml
+++ b/org.oasis-open.common/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin id="org.oasis-open.common" version="1.0">
+  <feature extension="ant.import" file="oasis-common-build.xml"/>
+  <feature extension="depend.preprocess.post" value="add-identifiers"/>
+</plugin>

--- a/org.oasis-open.common/xsl/add-identifiers.xsl
+++ b/org.oasis-open.common/xsl/add-identifiers.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    
+    <xsl:param name="idprefix" select="'lnk_'" as="xs:string"/>
+
+    <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
+    <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
+    <xsl:variable name="msgprefix" select="''"/>
+    
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="*[empty(@id)]
+        [contains(class,' topic/abstract ') or contains(@class,' topic/bodydiv ') or contains(@class,' topic/dd ') or
+        contains(@class,' topic/dt ') or contains(@class,' topic/div ') or contains(@class,' topic/dl ') or
+        contains(@class,' topic/draft-comment ') or contains(@class,' topic/example ') or contains(@class,' topic/fig ') or
+        contains(@class,' topic/figgroup ') or contains(@class,' topic/image ') or contains(@class,' topic/include ') or
+        contains(@class,' topic/foreign ') or contains(@class,' topic/itemgroup ') or contains(@class,' topic/li ') or
+        contains(@class,' topic/lines ') or contains(@class,' topic/link ') or contains(@class,' topic/lq ') or
+        contains(@class,' topic/note ') or contains(@class,' topic/object ') or contains(@class,' topic/ol ') or
+        contains(@class,' topic/p ') or contains(@class,' topic/ph ') or contains(@class,' topic/pre ') or
+        contains(@class,' topic/q ') or contains(@class,' topic/row ') or contains(@class,' topic/section ') or
+        contains(@class,' topic/sectiondiv ') or contains(@class,' topic/simpletable ') or contains(@class,' topic/sl ') or
+        contains(@class,' topic/sli ') or contains(@class,' topic/strow ') or contains(@class,' topic/table ') or
+        contains(@class,' topic/title ') or contains(@class,' topic/ul ') or contains(@class,' topic/shortdesc ')]">
+        
+        <xsl:copy>
+            <xsl:attribute name="id" select="concat($idprefix,generate-id(.))"/>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+        
+    </xsl:template>
+    
+    
+</xsl:stylesheet>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Creates a plug-in intended for common functions / processing add-ons to any OASIS output.

Starts by adding one function to ensure that every block element has a generated ID, meaning that for HTML a reader will be able to link directly to any block in the spec. This has come up before, and came up again today during a session at DITA Europe.

For example, if someone has a question about (or wants to refer to) a specific list item in a set of rules, this ensures they can link directly to that item.

This does not guarantee stable IDs between builds; for stable IDs, the `@id` attribute should be set in the source.