### PR TITLE
Refactor PDF code to make it usable by FOP

### DIFF
--- a/org.oasis-open.pdf/build-oasis-pdf.xml
+++ b/org.oasis-open.pdf/build-oasis-pdf.xml
@@ -11,36 +11,43 @@
 <project name="org.oasis-open.pdf" default="dita2oasis-pdf-committeeNote">
  
       <!-- Build OASIS committee note -->
-      <target xmlns:dita="http://dita-ot.sourceforge.net" name="dita2oasis-pdf-committeeNote">
+      <target name="dita2oasis-pdf-committeeNote" depends="pdf-committeeNote-init, dita2pdf2"/>
+  
+      <target name="pdf-committeeNote-init">
           <property name="customization.dir" 
                     location="${dita.plugin.org.oasis-open.pdf.dir}/cfg"/>
           <property name="args.xsl.pdf"
                     location="${dita.plugin.org.oasis-open.pdf.dir}/cfg/fo/xsl/oasis-cn-topic2fo-shell.xsl"/>
           <property name="pdf.formatter" value="ah"/>
           <property name="args.chapter.layout" value="BASIC"/>
-          <antcall target="dita2pdf2"/>
-        </target>
+      </target>
   
-        <!-- Build OASIS specification -->
-      <target xmlns:dita="http://dita-ot.sourceforge.net" name="dita2oasis-pdf-specification">
-          <property name="customization.dir" 
-                    location="${dita.plugin.org.oasis-open.pdf.dir}/cfg"/>
-          <property name="args.xsl.pdf"
-                    location="${dita.plugin.org.oasis-open.pdf.dir}/cfg/fo/xsl/oasis-spec-topic2fo-shell.xsl"/>
-          <property name="pdf.formatter" value="ah"/>
-          <property name="args.chapter.layout" value="BASIC"/>
-          <antcall target="dita2pdf2"/>
-        </target>
+      <!-- Build OASIS specification -->
+      <target name="dita2oasis-pdf-specification" depends="pdf-spec-init, dita2pdf2"/>
+        
+      <target name="pdf-spec-init">
+        <property name="customization.dir" 
+                  location="${dita.plugin.org.oasis-open.pdf.dir}/cfg"/>
+        <condition property="args.xsl.pdf" 
+                   value="${dita.plugin.org.oasis-open.pdf.dir}/cfg/fo/xsl/oasis-spec-topic2fo-fop-shell.xsl">
+          <equals arg1="${pdf.formatter}" arg2="fop"/>
+        </condition>
+        <property name="args.xsl.pdf"
+                  location="${dita.plugin.org.oasis-open.pdf.dir}/cfg/fo/xsl/oasis-spec-topic2fo-shell.xsl"/>
+        <property name="pdf.formatter" value="ah"/>
+        <property name="args.chapter.layout" value="BASIC"/>
+      </target>
   
           <!-- Build OASIS TC document -->
-      <target xmlns:dita="http://dita-ot.sourceforge.net" name="dita2oasis-pdf-generic">
+      <target name="dita2oasis-pdf-generic" depends="oasis-generic-pdf-init, dita2pdf2"/>
+  
+      <target name="oasis-generic-pdf-init">
           <property name="customization.dir" 
                     location="${dita.plugin.org.oasis-open.pdf.dir}/cfg"/>
           <property name="args.xsl.pdf"
                     location="${dita.plugin.org.oasis-open.pdf.dir}/cfg/fo/xsl/oasis-tc-topic2fo-shell.xsl"/>
           <property name="pdf.formatter" value="fop"/>
           <property name="args.chapter.layout" value="BASIC"/>
-          <antcall target="dita2pdf2"/>
-        </target>
+      </target>
      
 </project>

--- a/org.oasis-open.pdf/cfg/fo/xsl/oasis-spec-topic2fo-fop-shell.xsl
+++ b/org.oasis-open.pdf/cfg/fo/xsl/oasis-spec-topic2fo-fop-shell.xsl
@@ -1,0 +1,19 @@
+<?xml version='1.0'?>
+
+<!-- ===================== CHANGE LOG ================================ -->
+<!--                                                                   -->
+<!-- 08 May 2019 KJE: Original creation                                -->
+<!-- 16 May 2019 KJE: Changed name of plug-in                          -->
+<!--                                                                   -->
+<!-- ================================================================= --> 
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0">
+
+    <xsl:import href="oasis-spec-topic2fo-shell.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2.fop:xsl/fo/index_fop.xsl"/>
+    
+    <xsl:output method="xml" encoding="utf-8" indent="no"/>
+
+</xsl:stylesheet>


### PR DESCRIPTION
* Refactors the transform definitions to remove extra XMLNS attribute
* Move property definitions into "init" task to use dependency chain rather than `<antcall>`
* Add new XSL shell that works with FOP, overriding the indexing code used by Antenna House