### PR TITLE
Fix empty table cell

### DIFF
--- a/org.oasis-open.pdf/cfg/fo/xsl/oasis-cn-static-content.xsl
+++ b/org.oasis-open.pdf/cfg/fo/xsl/oasis-cn-static-content.xsl
@@ -168,6 +168,7 @@
                             <!--<fo:block xsl:use-attribute-sets="default_footer" text-align="center">
                                 <xsl:value-of select="$cnLevel"/>
                             </fo:block>-->
+                            <fo:block></fo:block>
                         </fo:table-cell>
                         <fo:table-cell>
                             <!-- approval date -->


### PR DESCRIPTION
Table cells require an `fo:block` child; FOP fails with the empty cell, so adding an empty block into the cell.