### PR TITLE
Add next/previous links with OASIS style

### DIFF
--- a/org.oasis-open.dita.publishing/plugin.xml
+++ b/org.oasis-open.dita.publishing/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin id="org.oasis-open.dita.publishing" version="1.0">
   <feature extension="ant.import" file="oasis-common-build.xml"/>
-  <!--<feature extension="depend.preprocess.post" value="add-identifiers"/>-->
+  <feature extension="dita.xsl.maplink" value="xsl/maplink_oasis.xsl" type="file"/>
   <template file="oasis-common-build_template.xml"/>
 </plugin>

--- a/org.oasis-open.dita.publishing/xsl/maplink_oasis.xsl
+++ b/org.oasis-open.dita.publishing/xsl/maplink_oasis.xsl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Create next/previous linking that goes through
+    the map from start to finish, regardless of 
+    parent/child sequencing.
+-->
+
+<xsl:stylesheet version="2.0" 
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+                exclude-result-prefixes="xs dita-ot">
+  
+  <!-- Check if "oasislinks" is a link type; if so, apply our custom next/previous -->
+  <xsl:template match="*[contains(@class, ' map/topicref ')]" mode="link-from">
+    <xsl:choose>
+      <xsl:when test="$include.roles = 'oasislinks'">
+        <xsl:apply-templates select="." mode="link-to-oasis-next-prev"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:next-match/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <xsl:template match="*" mode="link-to-oasis-next-prev"/>
+  <xsl:template match="*[contains(@class,' map/topicref ')]
+    [ancestor-or-self::*[contains(@class,' bookmap/chapter ') or contains(@class,' bookmap/appendix ')]]"
+    mode="link-to-oasis-next-prev">
+    
+    <!-- Previous: if there is a preceding sibling, go there and dig for children,
+      find the last actual topicref before this one. 
+      Otherwise, previous is the parent. -->
+    <xsl:choose>
+      <xsl:when test="preceding-sibling::*[contains(@class,' map/topicref ')][@href]">
+        <xsl:apply-templates select="preceding-sibling::*[contains(@class,' map/topicref ')][@href][1]" mode="find-previous-oasis-link"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="parent::*" mode="link">
+          <xsl:with-param name="role">previous</xsl:with-param>
+        </xsl:apply-templates>
+      </xsl:otherwise>
+    </xsl:choose>
+    
+    <!-- If there is a child, the first child is the next topic.
+      Otherwise, go back up and look for next topic after parent (or grandparent, or ...) -->
+    <xsl:choose>
+      <xsl:when test="*[contains(@class,' map/topicref ')][@href]">
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')][@href][1]" mode="link">
+          <xsl:with-param name="role">next</xsl:with-param>
+        </xsl:apply-templates>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="." mode="find-next-oasis-link"/>
+      </xsl:otherwise>
+    </xsl:choose>
+      
+  </xsl:template>
+  
+  <!-- Go to previous, look at last child, keep going down, to find the true "last" -->
+  <xsl:template match="*" mode="find-previous-oasis-link">
+    <xsl:choose>
+      <xsl:when test="*[contains(@class,' map/topicref ')][@href]">
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')][@href][last()]" mode="find-previous-oasis-link"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="." mode="link">
+          <xsl:with-param name="role">previous</xsl:with-param>
+        </xsl:apply-templates>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <!-- Go to next, or go back up a level (or more) and then go to next. -->
+  <xsl:template match="*" mode="find-next-oasis-link">
+    <xsl:choose>
+      <xsl:when test="following-sibling::*[contains(@class,' map/topicref ')][@href]">
+        <xsl:apply-templates select="following-sibling::*[contains(@class,' map/topicref ')][@href][1]" mode="link">
+          <xsl:with-param name="role">next</xsl:with-param>
+        </xsl:apply-templates>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="parent::*" mode="find-next-oasis-link"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+</xsl:stylesheet>

--- a/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
+++ b/org.oasis.spec.xhtml/build_dita2spec-xhtml.xml
@@ -16,6 +16,10 @@
   </target>
 
   <target name="dita2spec-xhtml.init">
+    <!-- Adding "oasislinks" as a link type ensures our custom
+      next/previous links only end up affecting the OASIS html output.
+      The maplink XSL is in there for other builds but does nothing. -->
+    <property name="include.rellinks" value="friend next previous oasislinks"/>
     <property name="args.copycss" value="yes"/>
     <condition property="args.cssroot"
       value="${dita.plugin.org.oasis.spec.xhtml.dir}${file.separator}resource">
@@ -40,12 +44,6 @@
         <isset property="args.xsl"/>
       </not>
     </condition>
-    
-    <delete failonerror="false">
-      <fileset dir="${output.dir}">
-        <exclude name="**/*.zip"/>
-      </fileset>
-    </delete>
   </target>
   
   <target name="generate-xhtml-footer" unless="args.ftr">


### PR DESCRIPTION
Replaces the old (no longer working) next/previous links for HTML output with a new override based on latest DITA-OT coding.