### PR TITLE
Add spec-html5 transform type

### DIFF
--- a/org.oasis-open.dita.publishing/html5-params.xml
+++ b/org.oasis-open.dita.publishing/html5-params.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<parameters>
+  <param name="oasis.landing.page" expression="${dita.map.filename.root}${out.ext}"/>
+  <param name="oasis.spec.descriptor" expression="${oasis.spec.descriptor}"/>
+  <param name="oasis.track" expression="${oasis.track}"/>
+  <param name="oasis.copyright" expression="${oasis.copyright}"/>
+  <param name="oasis.spec.date" expression="${oasis.spec.date}"/>
+</parameters>

--- a/org.oasis-open.dita.publishing/oasis-common-build_template.xml
+++ b/org.oasis-open.dita.publishing/oasis-common-build_template.xml
@@ -82,5 +82,93 @@
 		</pipeline>
 	</target>
 	
+	<!-- Set defaults if values have not been passed in -->
+	<target name="oasis.common.init">
+		<tstamp>
+			<format property="default-publish-date" pattern="d MMMM yyyy" locale="en"/>
+		</tstamp>
+		<tstamp>
+			<format property="default-current-year" pattern="yyyy" locale="en"/>
+		</tstamp>
+		<property name="oasis.spec.descriptor" value="dita-v2-XX"/>
+		<property name="oasis.track" value="Standards Track Work Product"/>
+		<property name="oasis.copyright" value="Copyright © OASIS Open ${default-current-year}. All Rights Reserved."/>
+		<property name="oasis.spec.date" value="${default-publish-date}"/>
+	</target>
+	
+	<!-- Build OASIS style HTML5 output -->
+	<target
+		depends="oasis.common.init,
+		dita2spec-html5.init,
+		html5.init,
+		build-init,
+		preprocess2.oasis,
+		override.html5.topic.init,
+		html5.topic,
+		oasis-html5-coverpage,
+		html5.css,
+		return-oasis-html5"
+		name="dita2spec-html5" description="OASIS Specification HTML5 transform">
+	</target>
+	
+	<target name="dita2spec-html5.init">
+		<!-- Adding "oasislinks" as a link type ensures our custom
+      next/previous links only end up affecting the OASIS html output.
+      The maplink XSL is in there for other builds but does nothing. -->
+		<property name="include.rellinks" value="friend next previous oasislinks"/>
+		<property name="args.copycss" value="yes"/>
+		<property name="args.cssroot"
+			value="${dita.plugin.org.oasis.spec.xhtml.dir}${file.separator}resource"/>
+		<property name="args.css" value="oasis.css"/>
+		<property name="args.outext" value=".html"/>
+		<property name="args.xsl" 
+			value="${dita.plugin.org.oasis-open.dita.publishing.dir}${file.separator}xslhtml5${file.separator}dita2oasis-html5_shell.xsl"/>
+		
+		<!-- Setup a temp "output" directory within temp processing directory, so we can zip output -->
+		<property name="temp.output.dir.name" value="temp_outdir"/>
+	</target>
+	
+	<!-- Need to set validate="no" on the html5.map.url property setting below.
+		Done by default in 3.6, added this override for use with 3.5.3 -->
+	<target name="override.html5.topic.init">
+		<local name="html5.map"/>
+		<loadfile property="html5.map" srcfile="${dita.temp.dir}/${user.input.file.listfile}" unless:set="noMap">
+			<filterchain>
+				<headfilter lines="1"/>
+			</filterchain>
+		</loadfile>
+		<makeurl property="html5.map.url" file="${dita.temp.dir}/${html5.map}" validate="no" unless:set="noMap"/>
+	</target>
+	
+	<target name="oasis-html5-coverpage">
+		<pipeline message="Build OASIS HTML5 cover page" taskname="oasis-cover">
+			<xslt basedir="${dita.temp.dir}"
+				destdir="${dita.output.dir}"
+				extension="${out.ext}"
+				style="${dita.plugin.org.oasis-open.dita.publishing.dir}/xslhtml5/oasis_coverpage.xsl">
+				<ditaFileset format="ditamap" input="true"/>
+				<param name="OUTEXT" expression="${out.ext}" if:set="out.ext"/>
+				<param name="version-id" expression="${args.oasis.bookmeta.version-id}"/>
+				<param name="errata-num" expression="${args.oasis.bookmeta.errata-num}"/>
+				<param name="stage-abbrev" expression="${args.oasis.bookmeta.stage-abbrev}"/>
+				<param name="revision-num" expression="${args.oasis.bookmeta.revision-num}"/>
+				<param name="part-number" expression="${args.oasis.bookmeta.part-number}"/>
+				<param name="spec-release-type" expression="${args.oasis.bookmeta.spec-release-type}"/>
+				<xmlcatalog refid="dita.catalog"/>
+			</xslt>
+		</pipeline>
+	</target>
+	
+	<target name="return-oasis-html5">
+		<property name="oasis-haml5-zipname" value="${dita.map.filename.root}.zip"/>
+		<zip destfile="${output.dir}/${oasis-haml5-zipname}" basedir="${dita.output.dir}">
+			<include name="**/*"/>
+		</zip>
+		
+		<!-- Also return individual files -->
+		<copy todir="${output.dir}">
+			<fileset dir="${dita.output.dir}"/>
+		</copy>
+	</target>
 	
 </project>

--- a/org.oasis-open.dita.publishing/plugin.xml
+++ b/org.oasis-open.dita.publishing/plugin.xml
@@ -3,4 +3,7 @@
   <feature extension="ant.import" file="oasis-common-build.xml"/>
   <feature extension="dita.xsl.maplink" value="xsl/maplink_oasis.xsl" type="file"/>
   <template file="oasis-common-build_template.xml"/>
+  <transtype name="spec-html5" extends="html5">    
+  </transtype>
+  <feature extension="dita.conductor.html5.param" type="file" value="html5-params.xml"/>
 </plugin>

--- a/org.oasis-open.dita.publishing/xsl/add-topic-numbers.xsl
+++ b/org.oasis-open.dita.publishing/xsl/add-topic-numbers.xsl
@@ -45,6 +45,7 @@
     
     <xsl:template match="@* | node()">
         <xsl:param name="spectopicnum"/>
+        <xsl:param name="spectocid"/>
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>
         </xsl:copy>
@@ -53,6 +54,8 @@
     <!-- If a topicref has an associated topic, AND is part of a chapter or appendix, 
         get the TOC number using the lookup $fulltoc, and place it in:
         <resourceid appid="X.Y.Z" appname="spectopicnum"> (plus class, xtrf, xtrc)
+        
+        In addition, add a generated ID to use for unique TOC IDs in the HTML TOC
         -->
     <xsl:template match="*[contains(@class,' map/topicref ')]
         [@href]
@@ -67,20 +70,24 @@
             <xsl:if test="empty(*[contains(@class,' map/topicmeta ')])">
                 <topicmeta class="- map/topicmeta " xtrf="{@xtrf}" xtrc="{@xtrc}">
                     <resourceid class="- topic/resourceid " appname="spectopicnum" appid="{$tocnum}" xtrf="{@xtrf}" xtrc="{@xtrc}"/>
+                    <resourceid class="- topic/resourceid " appname="spectocid" appid="{$id-in-gentoc}" xtrf="{@xtrf}" xtrc="{@xtrc}"/>
                 </topicmeta>
             </xsl:if>
             <xsl:apply-templates select="node()">
                 <xsl:with-param name="spectopicnum" select="$tocnum"/>
+                <xsl:with-param name="spectocid" select="$id-in-gentoc"/>
             </xsl:apply-templates>
         </xsl:copy>
     </xsl:template>
     
     <xsl:template match="*[contains(@class,' map/topicmeta ')]">
         <xsl:param name="spectopicnum" as="xs:string?"/>
+        <xsl:param name="spectocid" as="xs:string?"/>
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>
             <xsl:if test="string-length($spectopicnum) > 0">
                 <resourceid class="- topic/resourceid " appname="spectopicnum" appid="{$spectopicnum}" xtrf="{@xtrf}" xtrc="{@xtrc}"/>
+                <resourceid class="- topic/resourceid " appname="spectocid" appid="{$spectocid}" xtrf="{@xtrf}" xtrc="{@xtrc}"/>
             </xsl:if>
         </xsl:copy>
     </xsl:template>

--- a/org.oasis-open.dita.publishing/xslhtml5/dita2oasis-html5_shell.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/dita2oasis-html5_shell.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!-- Tagsmiths: Changed XSLT to version 2.0 -04oct13-->
+<xsl:stylesheet version="2.0" xmlns:oa="http://www.oasis-open.org"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs oa"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  
+  <xsl:import href="plugin:org.dita.html5:xsl/dita2html5.xsl"/>
+  <xsl:import href="oasis-html-footer.xsl"/>
+
+</xsl:stylesheet>

--- a/org.oasis-open.dita.publishing/xslhtml5/oasis-html-footer.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/oasis-html-footer.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!-- Tagsmiths: Changed XSLT to version 2.0 -04oct13-->
+<xsl:stylesheet version="2.0" xmlns:oa="http://www.oasis-open.org"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs oa"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  
+  <xsl:param name="oasis.landing.page" select="''"/>
+  <xsl:param name="oasis.spec.descriptor" select="''"/>
+  <xsl:param name="oasis.track" select="'Standards Track Work Product'"/>
+  <xsl:param name="oasis.copyright" select="''"/>
+  <xsl:param name="oasis.spec.date" select="''"/>
+  
+  <xsl:variable name="path.to.landing.page">
+    <xsl:value-of select="/processing-instruction('path2mapdir-uri')"/>
+  </xsl:variable>
+  
+  <xsl:template name="processFTR">
+    <footer role="contentinfo">
+      <div>
+        <p></p>
+        <p>Return to <a href="../../{$path.to.landing.page}{$oasis.landing.page}#{/*/*/resourceid[@appname='spectocid']/@appid}">main page</a>.</p>
+        <table class="footer-table" role="presentation">
+          <colgroup>
+            <col width="25%"/>
+            <col width="55%"/>
+            <col width="20%"/>
+          </colgroup>
+          <tr>
+            <td class="footer-left">
+              <p><xsl:value-of select="$oasis.spec.descriptor"/></p>
+              <p><xsl:value-of select="$oasis.track"/></p>
+            </td>
+            <td class="footer-center"><xsl:value-of select="$oasis.copyright"/></td>
+            <td class="footer-right"><xsl:value-of select="$oasis.spec.date"/></td>
+          </tr>
+        </table>
+      </div>
+    </footer>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/org.oasis-open.dita.publishing/xslhtml5/oasis_coverpage.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/oasis_coverpage.xsl
@@ -1,0 +1,556 @@
+<?xml version="1.0"?>
+<!-- Tagsmiths: Changed XSLT to version 2.0 -04oct13-->
+<xsl:stylesheet version="2.0" xmlns:oa="http://www.oasis-open.org"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs oa"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <!-- Tagsmiths: Eliminated DITAEXT parameter. Now using 2.0 replace() function to capture basename. -04oct13-->
+  <xsl:param name="DITAEXT" select="'.dita'"/>
+  <xsl:param name="OUTEXT" select="'.html'"/>
+
+  <xsl:param name="oasisDitaUri">http://docs.oasis-open.org/dita/dita</xsl:param>
+
+  <xsl:param name="FOOTER"/>
+
+  <!-- Tagsmiths: The following paramaters are components used for oasis naming conventions. 21jul16 -->
+  <xsl:param name="version-id"/>
+  <xsl:param name="errata-num"/>
+  <xsl:param name="stage-abbrev"/>
+  <xsl:param name="revision-num"/>
+  <xsl:param name="part-number"/>
+  <xsl:param name="spec-release-type"/>
+
+  <xsl:output method="html"
+    encoding="UTF-8"
+    indent="no"
+    doctype-system="about:legacy-compat"
+    omit-xml-declaration="yes"/>
+
+  <xsl:variable name="newline">
+    <xsl:text>
+</xsl:text>
+  </xsl:variable>
+
+  <xsl:variable name="pubWorkdir" select="/processing-instruction('workdir-uri')[1]"/>
+
+  <xsl:variable name="specSubtitle1"
+    select="
+      /*[contains(@class, ' bookmap/bookmap ')]
+      /*[contains(@class, ' bookmap/booktitle ')]
+      /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationSubtitle1']"/>
+  <xsl:variable name="specSubtitle2"
+    select="
+      /*[contains(@class, ' bookmap/bookmap ')]
+      /*[contains(@class, ' bookmap/booktitle ')]
+      /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationSubtitle2']"/>
+  <xsl:variable name="specLevel"
+    select="
+      /*[contains(@class, ' bookmap/bookmap ')]
+      /*[contains(@class, ' bookmap/booktitle ')]
+      /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationLevel']"/>
+  <xsl:variable name="specPrefix"
+    select="
+      /*[contains(@class, ' bookmap/bookmap ')]
+      /*[contains(@class, ' bookmap/booktitle ')]
+      /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationPrefix']"/>
+  <xsl:variable name="specScope"
+    select="
+      /*[contains(@class, ' bookmap/bookmap ')]
+      /*[contains(@class, ' bookmap/booktitle')]
+      /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationScope']"/>
+  <xsl:variable name="specVersion"
+    select="
+      /*[contains(@class, ' bookmap/bookmap ')]/*
+      /*[contains(@class, ' bookmap/bookmeta')]
+      /*[contains(@class, ' topic/prodinfo ')]
+      /*[contains(@class, ' topic/vrmlist ')]
+      /*[contains(@class, ' topic/vrm ')]/@version"/>
+
+  <xsl:variable name="revName">
+    <!-- errata-01-->
+    <xsl:if test="($errata-num castable as xs:double) and number($errata-num) &gt; 0">
+      <xsl:text>errata-</xsl:text>
+      <xsl:value-of select="$errata-num"/>
+    </xsl:if>
+  </xsl:variable>
+
+  <xsl:template match="/">
+    <html>
+      <xsl:value-of select="$newline"/>
+      <head>
+        <xsl:value-of select="$newline"/>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <xsl:value-of select="$newline"/>
+        <meta content="Copyright © OASIS Open 2016" name="copyright"/>
+        <xsl:value-of select="$newline"/>
+        <meta content=" Copyright © OASIS 2016" name="DC.rights.owner"/>
+        <xsl:value-of select="$newline"/>
+        <link href="http://docs.oasis-open.org/templates/css/OASIS_Specification_Template_v1-0.css"
+          rel="stylesheet" type="text/css"/>
+        <link href="oasis.css" rel="stylesheet" type="text/css"/>
+        <link href="commonltr.css" rel="stylesheet" type="text/css"/>
+        <xsl:value-of select="$newline"/>
+        <title>
+          <xsl:value-of select="$newline"/>
+          <xsl:apply-templates
+            select="/*/*[@outputclass = 'specificationTitles']/*[@outputclass = 'specificationShorttitle']"/>
+          <xsl:value-of select="$newline"/>
+        </title>
+        <xsl:value-of select="$newline"/>
+          <xsl:if
+            test="/*/*[contains(@class, ' bookmap/bookmeta ')]/*[@outputclass = 'thisVersion']/*[@format = 'html']/@href">
+            <xsl:value-of select="$newline"/>
+            <!--<base>
+              <xsl:attribute name="href">
+                <xsl:value-of select="/*/*[contains(@class,' bookmap/bookmeta ')]/*[@outputclass='thisVersion']/*[@format='html']/@href"/>
+              </xsl:attribute>
+            </base><xsl:value-of select="$newline"/>-->
+          </xsl:if>
+        <script type="text/javascript">
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');      
+          ga('create', 'UA-82127846-1', 'auto');
+          ga('send', 'pageview');      
+        </script>
+      </head>
+      <xsl:value-of select="$newline"/>
+      <body>
+        <xsl:value-of select="$newline"/>
+        <p>
+          <img src="http://docs.oasis-open.org/templates/OASISLogo.jpg" alt="OASIS logo" width="203"
+            height="54"/>
+        </p>
+        <xsl:value-of select="$newline"/>
+
+        <div>
+          <xsl:value-of select="$newline"/>
+          <p class="title">
+            <xsl:apply-templates
+              select="
+                /*[contains(@class, ' bookmap/bookmap ')]/
+                *[contains(@class, ' bookmap/booktitle ')]/
+                *[contains(@class, ' bookmap/mainbooktitle ')]"
+            />
+          </p>
+          <!-- Tagsmiths: Output the cover topic and the notices topic. -31oct13 -->
+          <p class="subtitle">
+            <!-- Part number >= zero means that this is a spec part document. 06dec17 -->
+            <xsl:choose>
+              <xsl:when test="($part-number castable as xs:double) and number($part-number) &lt; 0">
+                <xsl:choose>
+                  <!-- It's a draft -->
+                  <xsl:when
+                    test="($revision-num castable as xs:double) and number($revision-num) > 0">
+                    <span>
+                      <xsl:value-of select="$spec-release-type"/>
+                    </span>
+                  </xsl:when>
+                  <!-- It's final -->
+                  <xsl:otherwise>
+                    <span>OASIS Approved Errata</span>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:when>
+              <!-- If this is an errata and the revision number is non-zero ... -->
+              <xsl:when test="($errata-num castable as xs:double) and number($errata-num) > 0">                
+                <xsl:text>OASIS Standard </xsl:text>
+                <xsl:choose>
+                  <xsl:when
+                    test="($revision-num castable as xs:double) and number($revision-num) > 0">
+                    <span class="revised">
+                      <xsl:text>incorporating </xsl:text>
+                      <xsl:if test="$stage-abbrev = 'csprd'">
+                        <xsl:text> Public Review</xsl:text>
+                      </xsl:if>
+                      <xsl:text> Draft </xsl:text>
+                      <xsl:value-of select="$revision-num"/>
+                      <xsl:text> of Errata </xsl:text>
+                      <xsl:value-of select="$errata-num"/>
+                    </span>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:text> </xsl:text>
+                    <span class="revised">
+                      <xsl:text>incorporating Approved Errata</xsl:text>
+                    </span>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:when>
+
+            </xsl:choose>
+          </p>
+          <!-- Date -->
+          <xsl:if test="not(normalize-space($specSubtitle2) = '')">
+            <p class="subtitle">
+              <xsl:value-of select="$specSubtitle2"/>
+            </p>
+          </xsl:if>
+          <!-- Tagsmiths: Output the cover topic and the notices topic. -31oct13 -->
+          <p class="subtitle topmargin">
+            <xsl:value-of
+              select="
+                /*[contains(@class, ' bookmap/bookmap ')]
+                /*[contains(@class, ' bookmap/booktitle ')]
+                /*[contains(@class, ' bookmap/booktitlealt ')][@outputclass = 'specificationApproved']"
+            />
+          </p>
+          <!-- Tagsmiths: Output the cover topic and the notices topic. -31oct13 -->
+          <xsl:for-each select="/bookmap/frontmatter/notices/topicref">
+            <!-- Tagsmiths: Process these topics as frontmatter -->
+            <xsl:apply-templates select="document(@href)" mode="process-frontmatter"/>
+          </xsl:for-each>
+        </div>
+        <xsl:value-of select="$newline"/>
+        <div>
+          <xsl:value-of select="$newline"/>
+            <p class="heading1">Table of Contents</p>
+            <xsl:value-of select="$newline"/>
+            <xsl:apply-templates select="/*/*[contains(@class, ' bookmap/chapter ')]" mode="toc"/>
+            <xsl:apply-templates select="/*/*[contains(@class, ' bookmap/appendix ')]" mode="toc"/>
+          <p/>
+          <xsl:value-of select="$newline"/>
+          <div class="familylinks">
+            <xsl:value-of select="$newline"/>
+            <div class="titlepageinfodescription">
+              <xsl:variable name="firstTopic">
+                <xsl:value-of select="/*/*[contains(@class, ' bookmap/chapter ')][@href][1]/@href"/>
+              </xsl:variable>
+              <xsl:variable name="hoverHelp">
+                <xsl:apply-templates
+                  select="/*/*[contains(@class, ' bookmap/chapter ')][@href][1]/*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/shortdesc ')]"
+                />
+              </xsl:variable>
+              <strong>Next topic:</strong>
+              <xsl:text> </xsl:text>
+              <a>
+                <xsl:attribute name="href">
+                  <!-- Tagsmiths: The regular-expression in the following replace() function
+                       strips off the file extension from the filename in @href. -04oct13
+                  -->
+                  <xsl:value-of select="replace($firstTopic, '(.*)\..*', '$1')"/>
+                  <xsl:value-of select="$OUTEXT"/>
+                </xsl:attribute>
+                <xsl:if test="normalize-space($hoverHelp) != ''">
+                  <xsl:attribute name="title">
+                    <xsl:value-of select="normalize-space($hoverHelp)"/>
+                  </xsl:attribute>
+                  <xsl:apply-templates
+                    select="/*/*[contains(@class, ' bookmap/chapter ')][@href][1]" mode="getNum"/>
+                  <xsl:text> </xsl:text>
+                  <xsl:apply-templates
+                    select="/*/*[contains(@class, ' bookmap/chapter ')][@href][1]" mode="getTitle"/>
+                </xsl:if>
+              </a>
+            </div>
+            <xsl:value-of select="$newline"/>
+          </div>
+          <xsl:value-of select="$newline"/>
+        </div>
+        <xsl:value-of select="$newline"/>
+      </body>
+      <xsl:value-of select="$newline"/>
+    </html>
+  </xsl:template>
+
+  <!-- Tagsmiths: Begining of several templates for rendering cover and notices. -31oct13 -->
+  <xsl:template match="/" mode="process-frontmatter">
+    <xsl:choose>
+      <xsl:when test="*[@outputclass = 'cover']">
+        <xsl:apply-templates mode="cover"/>
+      </xsl:when>
+      <xsl:when test="*[@outputclass = 'frontmatternotices']">
+        <xsl:apply-templates mode="notices"/>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- Tagsmiths: Process the cover topic. -31oct13 -->
+  <xsl:template match="*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]"
+    mode="cover">
+    <p class="heading4">
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/section ')]" mode="cover">
+    <xsl:apply-templates mode="cover"/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/section ')]/*[contains(@class, ' topic/title ')]"
+    mode="cover">
+    <p class="titlepageinfo"><xsl:apply-templates/>:</p>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/p ')]" mode="cover">
+    <xsl:choose>
+      <xsl:when test="@outputclass = 'no-space-before'">
+        <p class="titlepageinfodescription">
+          <xsl:apply-templates mode="cover"/>
+        </p>
+      </xsl:when>
+      <xsl:otherwise>
+        <p class="abstract">
+          <xsl:apply-templates mode="cover"/>
+        </p>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/sl ')]" mode="cover #default">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/sli ')]">
+    <xsl:choose>
+      <xsl:when test="parent::*/@outputclass = 'no-indent'">
+        <p class="titlepageinfodescription">
+          <xsl:apply-templates/>
+        </p>
+      </xsl:when>
+      <xsl:otherwise>
+        <p class="relatedwork">
+          <xsl:apply-templates/>
+        </p>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- Tagsmiths: Process the notices topic. -31oct13 -->
+  <xsl:template match="*[contains(@class, ' topic/ul ')]" mode="cover #default">
+    <ul class="ul">
+      <xsl:apply-templates/>
+    </ul>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/li ')]" mode="cover #default">
+    <li class="li">
+      <xsl:apply-templates/>
+    </li>
+  </xsl:template>
+  <!-- Tagsmiths: End of several templates for rendering cover and notices. -31oct13 -->
+
+  <xsl:template match="*[contains(@class, ' topic/p ')]" mode="notices">
+    <p class="normal">
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+  <xsl:template match="*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]"
+    mode="notices">
+    <p class="notices">
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+  <xsl:template match="*[contains(@class, ' topic/cite ')]">
+    <cite>
+      <xsl:apply-templates/>
+    </cite>
+  </xsl:template>
+  <!-- Tagsmiths: End of several templates for rendering cover and notices. -31oct13 -->
+
+
+  <xsl:template match="*[contains(@class, ' topic/xref ')]" mode="#default cover">
+    <xsl:variable name="topicWorkdir" select="/processing-instruction('workdir-uri')[1]"/>
+    <a>
+      <xsl:attribute name="href">
+        <xsl:choose>
+          <xsl:when test="matches(@scope, 'external')">
+            <xsl:value-of select="@href"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:variable name="absHref" select="resolve-uri(@href, $topicWorkdir)"/>
+            <xsl:variable name="hrefRelativeToPub"
+              select="oa:abspathToRelpath($absHref, $pubWorkdir)"/>
+            <xsl:variable name="hrefRelativeToPubRaw"
+              select="replace($hrefRelativeToPub, concat($DITAEXT, '#'), concat($OUTEXT, '#'), 'i')"/>
+            <xsl:value-of select="replace($hrefRelativeToPubRaw, '(.*#[^/]*)/(.*)', '$1__$2')"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+    </a>
+  </xsl:template>
+
+  <xsl:function name="oa:abspathToRelpath">
+    <xsl:param name="abspath" as="xs:string"/>
+    <xsl:param name="baseDirectory" as="xs:string"/>
+    <xsl:value-of select="replace($abspath, $baseDirectory, '')"/>
+  </xsl:function>
+
+  <!-- Tagsmiths: Add rendering for tm. -01nov13-->
+  <xsl:template match="*[contains(@class, ' topic/tm ')]">
+    <xsl:apply-templates/>
+    <xsl:choose>
+      <!-- ignore @tmtype=service or anything else -->
+      <xsl:when test="@tmtype = 'tm'">&#x2122;</xsl:when>
+      <xsl:when test="@tmtype = 'reg'">
+        <sup>&#xAE;</sup>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/ph ')]">
+
+    <xsl:choose>
+      <xsl:when test="@rev = $revName">
+        <span>
+          <xsl:attribute name="class">revised</xsl:attribute>
+          <xsl:apply-templates/>
+        </span>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates/>
+      </xsl:otherwise>
+    </xsl:choose>
+
+  </xsl:template>
+
+  <xsl:template match="*" mode="getTitle">
+    <xsl:choose>
+      <xsl:when
+        test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]">
+        <xsl:apply-templates
+          select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]"/>
+      </xsl:when>
+      <xsl:when test="@navtitle">
+        <xsl:value-of select="@navtitle"/>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="*[contains(@class, ' bookmap/chapter ')]" mode="getNum">
+    <xsl:choose>
+      <xsl:when
+        test="
+          contains(*[contains(@class, ' map/topicmeta ')]
+          /*[contains(@class, ' topic/data ')][@name = 'topicid']
+          /*[contains(@class, ' topic/data ')][@name = 'number']
+          /@value, '.0')">
+        <xsl:value-of
+          select="
+            substring-before(*[contains(@class, ' map/topicmeta ')]
+            /*[contains(@class, ' topic/data ')][@name = 'topicid']
+            /*[contains(@class, ' topic/data ')][@name = 'number']
+            /@value, '.0')"
+        />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of
+          select="
+            *[contains(@class, ' map/topicmeta ')]
+            /*[contains(@class, ' topic/data ')][@name = 'topicid']
+            /*[contains(@class, ' topic/data ')][@name = 'number']
+            /@value"
+        />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <!--<xsl:template match="*[contains(@class,' bookmap/appendix ')]" mode="getNum">
+    <xsl:value-of select="substring-before(*[contains(@class,' map/topicmeta ')]
+                                              /*[contains(@class,' topic/data ')][@name='topicid']
+                                              /*[contains(@class,' topic/data ')][@name='number']
+                                              /@value,'.')"/>
+  </xsl:template>-->
+  <xsl:template match="*" mode="getNum">
+    <xsl:value-of
+      select="
+        *[contains(@class, ' map/topicmeta ')]
+        /*[contains(@class, ' topic/data ')][@name = 'topicid']
+        /*[contains(@class, ' topic/data ')][@name = 'number']
+        /@value"
+    />
+  </xsl:template>
+  <xsl:template match="*" mode="getId">
+    <xsl:value-of select="*/resourceid[@appname='spectocid']/@appid"/>
+  </xsl:template>
+
+  <xsl:template match="*" mode="toc">
+    <xsl:param name="indent" select="''"/>
+    <xsl:variable name="thistitle">
+      <xsl:apply-templates select="." mode="getTitle"/>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="normalize-space($thistitle) != ''">
+        <xsl:variable name="topicNum">
+          <xsl:apply-templates select="." mode="getNum"/>
+        </xsl:variable>
+        <xsl:variable name="topicId">
+          <xsl:apply-templates select="." mode="getId"/>
+        </xsl:variable>
+        <!-- Tagsmiths: The regular-expression in the following replace() function
+          strips off the file extension from the filename in @href. -04oct13
+        -->
+        <xsl:variable name="basename" select="replace(@href, '(.*)\..*', '$1')"/>
+        <p class="titlepageinfodescription">
+          <xsl:value-of select="$indent"/>
+          <xsl:value-of select="$topicNum"/>
+          <xsl:text> </xsl:text>
+          <a id="{$topicId}">
+            <xsl:attribute name="href">
+              <xsl:value-of select="$basename"/>
+              <xsl:value-of select="$OUTEXT"/>
+              <xsl:text>#</xsl:text>
+              <xsl:choose>
+                <xsl:when test="contains(@href, '#')">
+                  <xsl:value-of select="substring-after(@href, '#')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="$topicId"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:attribute>
+            <xsl:value-of select="$thistitle"/>
+          </a>
+        </p>
+        <xsl:value-of select="$newline"/>
+        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+          <xsl:with-param name="indent">
+            <xsl:value-of select="$indent"/>
+            <xsl:text>&#xA0;&#xA0;&#xA0;</xsl:text>
+          </xsl:with-param>
+        </xsl:apply-templates>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+          <xsl:with-param name="indent" select="$indent"/>
+        </xsl:apply-templates>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="text()">
+    <xsl:choose>
+      <xsl:when test="normalize-space(.) = ''"/>
+      <xsl:otherwise>
+        <xsl:value-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/author ')]" mode="cover notices #default">
+    <!-- Suppress it -->
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/dl ')]" mode="cover notices #default">
+    <dl class="cover">
+      <xsl:apply-templates/>
+    </dl>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/dlentry ')]">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/dt ')]">
+    <dt class="dlterm oasis-style-reference">
+      <xsl:apply-templates/>
+    </dt>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/dd ')]">
+    <dd class="oasis-style-reference">
+      <xsl:apply-templates/>
+    </dd>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/org.oasis.specification.pubmeta/plugin.xml
+++ b/org.oasis.specification.pubmeta/plugin.xml
@@ -13,7 +13,7 @@
   <!-- Provide a version (default is 1.0 if not specified) -->
   <feature extension="package.version" value="1.0.0"/>
 
-  <feature extension="depend.preprocess.post" value="pub-meta-to-ant-props" type="text"/>
-  <feature extension="dita.conductor.target" value="build-pubmeta.xml" type="file"/>
+  <!--<feature extension="depend.preprocess.post" value="pub-meta-to-ant-props" type="text"/>
+  <feature extension="dita.conductor.target" value="build-pubmeta.xml" type="file"/>-->
 
 </plugin>


### PR DESCRIPTION
Add new transtype `spec-html5` that should make the older XHTML version obsolete.

Cover page formatting largely based on the XHTML transform type and still needs some cleanup, but the TOC portion works well.