### PR TITLE
Modify presentation of inline conformance clauses

### DIFF
--- a/org.oasis-open.dita.publishing/oasis-common-build_template.xml
+++ b/org.oasis-open.dita.publishing/oasis-common-build_template.xml
@@ -66,6 +66,9 @@
 	process all files looking for the hook to turn into a list. -->
 	<target name="generate-rfc-list" if="aggregate.rfc.topics">
 		
+		<property name="rfc.conformance.prefix" value="DITA.CONF."/>
+		<property name="tempfile.with.rfc.file" value="${dita.temp.dir}/rfcfile.txt"/>
+		<makeurl property="store.dita.rfc.filename" file="${tempfile.with.rfc.file}" validate="no"/>
 		<property name="rfclist.file" value="${dita.temp.dir}/rfclist.xml"/>
 		
 		<available file="${dita.temp.dir}/${user.input.file}" property="rfc.use.input.file.name"/>
@@ -75,11 +78,28 @@
 				<headfilter lines="1"/>
 			</filterchain>
 		</loadfile>
-		
 		<condition property="rfc.input.map" value="${dita.temp.dir}/${user.input.file}">
 			<isset property="rfc.use.input.file.name"/>
 		</condition>
 		<property name="rfc.input.map" value="${dita.temp.dir}/${rfc.renamed.map}"/>
+		
+		<pipeline message="Find the RFC items to enable two way linking" taskname="locate-rfc-items">
+			<xslt basedir="${dita.temp.dir}"
+				style="${dita.plugin.org.oasis-open.dita.publishing.dir}/xsl/locate-rfc-items.xsl"
+				filenameparameter="FILENAME"
+				filedirparameter="FILEDIR">
+				<ditaFileset format="dita" processingRole="normal"/>
+				<param name="store.dita.rfc.filename" expression="${store.dita.rfc.filename}"/>
+				<xmlcatalog refid="dita.catalog"/>
+			</xslt>
+		</pipeline>
+		
+		<loadfile property="rfclist.dita.topic" srcfile="${tempfile.with.rfc.file}">
+			<filterchain>
+				<headfilter lines="1"/>
+			</filterchain>
+		</loadfile>
+		<echo> Aggregated RFC list goes in: ${rfclist.dita.topic}</echo>
 		
 		<!-- Process the map, which walks topics looking for RFC items. -->
 		<pipeline message="Collect RFC statements" taskname="collect-rfclist">
@@ -87,6 +107,7 @@
 				style="${dita.plugin.org.oasis-open.dita.publishing.dir}/xsl/collect-rfclist.xsl"
 				in="${rfc.input.map}"
 				out="${rfclist.file}">
+				<param name="rfc.conformance.prefix" expression="${rfc.conformance.prefix}"/>
 				<xmlcatalog refid="dita.catalog"/>
 			</xslt>
 		</pipeline>
@@ -102,6 +123,7 @@
 				filedirparameter="FILEDIR">
 				<ditaFileset format="dita" processingRole="normal"/>
 				<param name="rfclist.file" expression="${rfclist.file}"/>
+				<param name="rfclist.dita.topic" expression="${rfclist.dita.topic}"/>
 				<xmlcatalog refid="dita.catalog"/>
 			</xslt>
 		</pipeline>
@@ -169,7 +191,7 @@
 		<property name="include.rellinks" value="friend next previous oasislinks"/>
 		<property name="args.copycss" value="yes"/>
 		<property name="args.cssroot"
-			value="${dita.plugin.org.oasis.spec.xhtml.dir}${file.separator}resource"/>
+			value="${dita.plugin.org.oasis-open.dita.publishing.dir}${file.separator}resources"/>
 		<property name="args.css" value="oasis.css"/>
 		<property name="args.outext" value=".html"/>
 		<property name="args.xsl" 

--- a/org.oasis-open.dita.publishing/resources/OASIS_Specification_Template_v1-0.css
+++ b/org.oasis-open.dita.publishing/resources/OASIS_Specification_Template_v1-0.css
@@ -1,0 +1,251 @@
+.abstract {
+	position: relative;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	margin-left: 25px;
+	display: block;
+}
+.appendixheading1 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 18pt;
+	font-weight: bold;
+	list-style-type: upper-alpha;
+	color: #66116D;
+}
+.appendixheading2 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 14pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.appendixheading3 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 12pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.attribute {
+	font-family: "Courier New", Courier, mono;
+	font-size: 10pt;
+}
+.code {
+	font-family: "Courier New", Courier, mono;
+	font-size: 9pt;
+	background-color: #9999FF;
+	margin-left: 10%;
+	margin-right: 10%;
+	border-top-style: solid;
+	border-right-style: none;
+	border-bottom-style: solid;
+	border-left-style: none;
+	border-top-color: #000000;
+	border-right-color: #000000;
+	border-bottom-color: #000000;
+	border-left-color: #000000;
+	white-space: pre;
+}
+.codesmall {
+	font-family: "Courier New", Courier, mono;
+	font-size: 8pt;
+	background-color: #9999FF;
+	margin-right: 10%;
+	border-top-style: solid;
+	border-right-style: none;
+	border-bottom-style: solid;
+	border-left-style: none;
+	border-top-color: #000000;
+	border-right-color: #000000;
+	border-bottom-color: #000000;
+	border-left-color: #000000;
+	margin-left: 10%;
+	white-space: pre;
+}
+.codetemp {
+	font-family: "Courier New", Courier, mono;
+	font-size: 10pt;
+}
+.contributor {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	text-indent: 25px;
+}
+.datatype {
+	font-family: "Courier New", Courier, mono;
+	font-size: 10pt;
+}
+.definition {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	text-indent: 25px;
+}
+.definitionterm {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	font-weight: bold;
+}
+.element {
+	font-family: "Courier New", Courier, mono;
+	font-size: 10pt;
+}
+.emphasis {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	font-style: italic;
+}
+.example {
+	font-family: "Courier New", Courier, mono;
+	font-size: 9pt;
+	background-color: #9999FF;
+	margin-right: 25px;
+	margin-left: 25px;
+}
+.examplesmall {
+	font-family: "Courier New", Courier, mono;
+	font-size: 8pt;
+	margin-right: 25px;
+	margin-left: 25px;
+	background-color: #9999FF;
+}
+.heading1 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 18pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.heading2 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 14pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.heading3 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 13pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.heading4 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 12pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.heading5 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 11pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.heading6 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	font-weight: bold;
+	list-style-type: decimal;
+	color: #66116D;
+}
+.keyword {
+	font-family: "Courier New", Courier, mono;
+	font-size: 10pt;
+	font-style: normal;
+}
+.listbullet {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	list-style-type: disc;
+}
+.listbullet2 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	text-indent: 25px;
+	list-style-type: circle;
+}
+.listcontinue {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	text-indent: 25px;
+	margin-bottom: 0px;
+}
+.listcontinue2 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	text-indent: 50px;
+}
+.normal {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	margin-top: 0px;
+}
+.note {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	margin-left: 50px;
+	margin-right: 50px;
+}
+.notices {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 18pt;
+	font-weight: bold;
+	color: #66116D;
+}
+.ref {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	margin-left: 125px;
+	margin-top: 0px;
+}
+.refterm {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	font-weight: bold;
+	margin-bottom: 0px;
+	color: #66116D;
+}
+.relatedwork {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	text-indent: 50px;
+	list-style-type: disc;
+	list-style-position: outside;
+	display: list-item;
+	margin-top: 0px;
+	margin-bottom: 0px;
+}
+.subtitle {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 18pt;
+	font-weight: bold;
+	color: #66116D;
+}
+.title {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 24pt;
+	font-weight: bold;
+	color: #66116D;
+}
+.titlepageinfo {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	font-weight: bold;
+	color: #66116D;
+	margin-bottom: 0px;
+}
+.titlepageinfodescription {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	text-indent: 25px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+	font-style: normal;
+}
+.variable {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 10pt;
+	font-style: italic;
+}

--- a/org.oasis-open.dita.publishing/resources/oasis.css
+++ b/org.oasis-open.dita.publishing/resources/oasis.css
@@ -161,19 +161,20 @@ th{
   width: 100%;
 }
 
-div.rfc-container{
-    margin-left: 3em;
-    padding-left: 2em;
-    margin-right: 3em;
-    padding-right: 2em;
-    border-left: solid;
-    border-right: solid;
-    border-left-color: blue;
-    border-right-color: blue;
+table.rfctable{
+    margin-top: 1em;
+    width: 100%;
 }
 
-.rfc-inline-num{
-    font-weight: bold;
+td.rfctext{
+    padding-left: 1em;
+    border-left: solid;
+    border-left-color: blue;
+    border-left-width: 3px;
+    padding-right: 1em;
+    border-right: solid;
+    border-right-color: blue;
+    border-right-width: 3px;
 }
 
 .RFC-2119{

--- a/org.oasis-open.dita.publishing/resources/oasis.css
+++ b/org.oasis-open.dita.publishing/resources/oasis.css
@@ -1,0 +1,242 @@
+
+body{
+  background: #ffffff;
+  color: #000000;
+  margin: 14px;
+  font-size: 10pt;
+  font-family: Helvetica, Arial, sans-serif;
+}
+
+.subtitle{
+  margin-top: 0em;
+  margin-bottom: 0em;
+}
+
+.topmargin{
+  margin-top: 0.5em;
+}
+
+h1.topictitle1{
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 18pt;
+  font-weight: bold;
+  list-style-type: decimal;
+  color: #66116D;
+}
+
+h2.sectiontitle{
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14pt;
+  font-weight: bold;
+  list-style-type: decimal;
+  color: #66116D;
+}
+
+.fig{
+  margin-top: 1em;
+}
+
+td > ul,
+dd > ul{
+  padding-left: 1.4em;
+}
+
+ul{
+  padding-left: 3.0em;
+}
+
+td > ol,
+dd > ol{
+  padding-left: 1.6em;
+}
+
+ol{
+  padding-left: 3.2em;
+}
+
+pre.codeblock{
+  font-family: "Courier New", Courier, mono;
+  font-size: 9pt;
+  background-color: #EEEEFF;
+  margin-left: 2.8em;
+  margin-right: 2.8em;
+  border-top-style: solid;
+  border-width: 1px;
+  border-right-style: none;
+  border-bottom-style: solid;
+  border-left-style: none;
+  border-top-color: #000000;
+  border-right-color: #000000;
+  border-bottom-color: #000000;
+  border-left-color: #000000;
+  white-space: pre;
+}
+
+span.keyword{
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 10pt;
+}
+
+
+div.note{
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 10pt;
+  margin-left: 2.1em;
+  margin-right: 2.1em;
+}
+
+td > div.note,
+dd > div.note{
+  margin-left: 1.1em;
+}
+
+dd{
+  margin-left: 2.1em;
+}
+
+/*ul.linkpreviews {
+  background-color: #FFFCCC;
+	border: solid;
+	border-width:thin;
+	list-style-type: none
+}*/
+
+ul.ullinks,
+ul.linkpreviews{
+  background-color: #FFFCCC;
+  border: none;
+  border-width: thin;
+  list-style-type: none;
+  padding: 1em;
+}
+
+dt.oasis-style-reference{
+  font-weight: bold;
+  color: #66116D;
+  margin-left: 1.9em;
+  margin-bottom: 0.1em;
+  margin-top: 0.2em;
+}
+
+.dt{
+  margin-bottom: 0.1em;
+  margin-top: 0.2em;
+}
+
+dd.oasis-style-reference{
+  margin-left: 4em;
+}
+
+caption{
+  margin-top: 1em;
+  font-style: italic;
+}
+
+.table{
+  margin-bottom: 0.5em;
+}
+
+.thead{
+  background-color: #E8E8FF;
+}
+
+th{
+  background-color: #E8E8FF;
+}
+
+.stentry{
+  border-left: none;
+  border-top: none;
+  border-right: solid 1px;
+  border-bottom: solid 1px
+}
+
+.simpletable{
+  border-style: solid;
+  border-width: 1px;
+  margin-bottom: 0.5em;
+}
+
+.models{
+  width: 100%;
+}
+
+div.rfc-container{
+    margin-left: 3em;
+    padding-left: 2em;
+    margin-right: 3em;
+    padding-right: 2em;
+    border-left: solid;
+    border-right: solid;
+    border-left-color: blue;
+    border-right-color: blue;
+}
+
+.rfc-inline-num{
+    font-weight: bold;
+}
+
+.RFC-2119{
+  font-style: italic;
+}
+
+.title > .parameterentity,
+.title > .xmlatt,
+.title > .xmlelement,
+.title > .xmlpi,
+.dt > .parameterentity,
+.dt > .xmlatt,
+.dt > .xmlelement,
+.dt > .xmlpi{
+  font-family: inherit;
+  font-weight: inherit;
+  font-style: inherit;
+}
+
+/*Tagsmiths: The <u> element is used in errata to indicate added text. 12aug16*/
+u{
+  text-decoration: underline;
+  color: green;
+}
+
+/*Tagsmiths: The <line-through> element is used in errata to indicate deleted text. 12aug16*/
+.line-through{
+  text-decoration: line-through;
+  color: red;
+}
+
+/*Tagsmiths: The coverpage is not processed by dita2html.xsl. Consequently,
+  flagging is not supported. This class emulates flagging. 22jul16*/
+  
+.revised::before{
+  content: "►";
+}
+
+.revised::after{
+  content: "◄";
+}
+.revised, .red{
+  color: red !important;
+}
+
+.footer-table{
+  font-size: 8pt;
+  padding: 0pt;
+  margin-left: -2pt;
+  border-width: 0pt;
+  width: 100%;
+}
+
+.footer-left > p{
+  margin-top: 0pt;
+  margin-bottom: 0pt;
+  text-align: left;
+}
+
+.footer-center{
+  text-align: center;
+}
+
+.footer-right{
+  text-align: right;
+}

--- a/org.oasis-open.dita.publishing/xsl/generate-rfclist.xsl
+++ b/org.oasis-open.dita.publishing/xsl/generate-rfclist.xsl
@@ -52,6 +52,49 @@
     <xsl:attribute name="rfcnum" select="$rfcnum"/>    
     <xsl:attribute name="rfctarget" select="concat($dotdots, $rfclist.dita.topic, '/', $rfcnum)"/>
   </xsl:template>
+  
+  <xsl:template match="*[@rfclink]">
+    <xsl:variable name="searchid" select="@rfclink"/>
+    <xsl:variable name="rfcnum" select="document($rfclist.file)/rfclist/rfcitem[@rfclink = $searchid]/@rfcid"/>
+    <xsl:variable name="xref" as="element(xref)">
+      <xref class="- topic/xref " 
+        scope="local" href="{concat($dotdots, $rfclist.dita.topic, '/', $rfcnum)}"
+        xtrc="{@xtrc}" xtrf="{@xtrf}">
+          <xsl:value-of select="$rfcnum"/>
+        <desc class="- topic/desc ">Conformance clause number <xsl:value-of select="$rfcnum"/></desc>
+      </xref>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains(@class,' topic/li ')">
+        <xsl:copy>
+          <xsl:apply-templates select="@*"/>
+          <rfcdiv class="+ topic/div oasis/rfcdiv " xtrc="{@xtrc}" xtrf="{@xtrf}">
+            <rfcnum class="+ topic/div oasis/rfcnum " xtrc="{@xtrc}" xtrf="{@xtrf}">
+              <xsl:copy-of select="$xref"/>
+            </rfcnum>
+            <rfctext class="+ topic/div oasis/rfctext " xtrc="{@xtrc}" xtrf="{@xtrf}">
+              <xsl:apply-templates/>
+            </rfctext>
+          </rfcdiv>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:otherwise>
+        <rfcdiv class="+ topic/div oasis/rfcdiv " xtrc="{@xtrc}" xtrf="{@xtrf}" id="{@id}">
+          <rfcnum class="+ topic/div oasis/rfcnum " xtrc="{@xtrc}" xtrf="{@xtrf}">
+            <xsl:copy-of select="$xref"/>
+          </rfcnum>
+          <rfctext class="+ topic/div oasis/rfctext " xtrc="{@xtrc}" xtrf="{@xtrf}">
+            <xsl:next-match/>
+          </rfctext>
+        </rfcdiv>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <xsl:template match="*[@rfclink][not(contains(@class,' topic/li '))]/@id">
+    <!-- ID was moved up to the <rfcdiv> container, except for list items, 
+      which remain the target --> 
+  </xsl:template>
    
   <xsl:template match="*[contains(@class,' topic/data ')][@name='rfc-list']">
     <xsl:apply-templates select="document($rfclist.file)/*" mode="generate-rfclist">
@@ -66,7 +109,7 @@
     <xsl:if test="rfcitem">
       <simpletable relcolwidth="1* 7*" class="- topic/simpletable " outputclass="collected-rfc-rules" id="collected-rfc-rules-as-table" frame="all">
         <sthead class="- topic/sthead ">
-          <stentry class="- topic/stentry " dita-ot:y="1" dita-ot:x="1">Rule number</stentry>
+          <stentry class="- topic/stentry " dita-ot:y="1" dita-ot:x="1">Item</stentry>
           <stentry class="- topic/stentry " dita-ot:y="1" dita-ot:x="2">Conformance statement</stentry>
         </sthead>
         <xsl:for-each select="rfcitem">

--- a/org.oasis-open.dita.publishing/xsl/locate-rfc-items.xsl
+++ b/org.oasis-open.dita.publishing/xsl/locate-rfc-items.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Locate the RFC items and add a unique ID to help with later linking. -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    
+    <xsl:param name="FILENAME"/>
+    <xsl:param name="FILEDIR"/>
+    <xsl:param name="store.dita.rfc.filename" select="''"/>
+    
+    
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="@* | node()" mode="ignore-rfc-in-rfc">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" mode="ignore-rfc-in-rfc"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="*[(contains(@class,' topic/p ') or contains(@class,' topic/div ') or contains(@class,' topic/li ') or contains(@class,' topic/ph '))]
+        [descendant::*[contains(@class, ' topic/term ')][@outputclass = 'RFC-2119']]">
+        <xsl:copy>
+            <xsl:attribute name="rfclink" select="generate-id(.)"/>
+            <xsl:apply-templates select="@* | node()" mode="ignore-rfc-in-rfc"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="*[contains(@class,' topic/data ')][@name='rfc-list']">
+        <xsl:variable name="rfctopic">
+            <xsl:if test="$FILEDIR != '' and $FILEDIR != '.'">
+                <xsl:value-of select="concat($FILEDIR, '/')"/>
+            </xsl:if>
+            <xsl:value-of select="concat($FILENAME, '#', ancestor::*[contains(@class,' topic/topic ')][1]/@id)"/>
+        </xsl:variable>
+        <xsl:result-document href="{$store.dita.rfc.filename}" method="text">
+            <xsl:value-of select="$rfctopic"/>
+        </xsl:result-document>
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/org.oasis-open.dita.publishing/xslhtml5/dita2oasis-html5_shell.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/dita2oasis-html5_shell.xsl
@@ -6,5 +6,6 @@
   
   <xsl:import href="plugin:org.dita.html5:xsl/dita2html5.xsl"/>
   <xsl:import href="oasis-html-footer.xsl"/>
+  <xsl:import href="format-rfc.xsl"/>
 
 </xsl:stylesheet>

--- a/org.oasis-open.dita.publishing/xslhtml5/format-rfc.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/format-rfc.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!-- Tagsmiths: Changed XSLT to version 2.0 -04oct13-->
+<xsl:stylesheet version="2.0" xmlns:oa="http://www.oasis-open.org"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs oa"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  
+  <!--
+    Extra attributes added to containers with RFC content:
+    <p 
+    rfcnum="DITA.CONF.003" 
+    rfctarget="../../non-normative/aggregated-RFC-2119-statements.dita#aggregated-RFC-2119-statements/DITA.CONF.003"
+  -->
+  <xsl:template match="*[@rfcnum][@rfctarget]">
+    <div class="rfc-container">
+      <div class="rfc-inline-num">
+        <xsl:variable name="makexref" as="element(xref)">
+          <xref class="- topic/xref " href="{@rfctarget}">
+            <xsl:copy-of select="@xtrc|@xtrf"/>
+            <xsl:value-of select="@rfcnum"/>
+          </xref>
+        </xsl:variable>
+        <xsl:apply-templates select="$makexref"/>
+      </div>
+      <div class="rfc-content"><xsl:next-match/></div>
+    </div>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/org.oasis-open.dita.publishing/xslhtml5/format-rfc.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/format-rfc.xsl
@@ -4,24 +4,35 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs oa"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
-  <!--
-    Extra attributes added to containers with RFC content:
-    <p 
-    rfcnum="DITA.CONF.003" 
-    rfctarget="../../non-normative/aggregated-RFC-2119-statements.dita#aggregated-RFC-2119-statements/DITA.CONF.003"
-  -->
-  <xsl:template match="*[@rfcnum][@rfctarget]">
-    <div class="rfc-container">
-      <div class="rfc-inline-num">
-        <xsl:variable name="makexref" as="element(xref)">
-          <xref class="- topic/xref " href="{@rfctarget}">
-            <xsl:copy-of select="@xtrc|@xtrf"/>
-            <xsl:value-of select="@rfcnum"/>
-          </xref>
-        </xsl:variable>
-        <xsl:apply-templates select="$makexref"/>
-      </div>
-      <div class="rfc-content"><xsl:next-match/></div>
+  <xsl:template match="*[contains(@class,' oasis/rfcdiv ')]">
+    <table role="presentation" class="rfctable">
+      <xsl:call-template name="setid"/>
+      <colgroup>
+        <col width="15%"/>
+        <col width="85%"/>
+      </colgroup>
+      <tbody>
+        <tr>
+          <td class="rfcnum">
+            <xsl:apply-templates select="rfcnum/node()"/>
+          </td>
+          <td class="rfctext">
+            <xsl:apply-templates select="rfctext/node()"/>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' oasis/rfcnum ')]">
+    <div class="rfc-number">
+      <p class="rfc-number"><xsl:apply-templates/></p>
+    </div>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' oasis/rfctext ')]">
+    <div class="rfc-content">
+      <xsl:apply-templates/>
     </div>
   </xsl:template>
 

--- a/org.oasis-open.pdf/cfg/fo/xsl/oasis-cn-custom-xsl.xsl
+++ b/org.oasis-open.pdf/cfg/fo/xsl/oasis-cn-custom-xsl.xsl
@@ -31,10 +31,37 @@
       </fo:inline>
    </xsl:template>
    
-   <xsl:template match="*[contains(@class, ' topic/p ')]
-         [descendant::*[contains(@class, ' topic/term ')][@outputclass = 'RFC-2119']]">
-      <fo:block xsl:use-attribute-sets="RFC-2119-statement">
-         <xsl:call-template name="commonattributes"/>
+   <xsl:template match="*[contains(@class,' oasis/rfcdiv ')]">
+      <!--<fo:block xsl:use-attribute-sets="RFC-2119-statement">
+         <xsl:apply-templates select="@id"/>
+         <xsl:apply-templates/>
+      </fo:block>-->
+      <fo:table margin-top="1em" padding-before="1em" id="{@id}">
+         <fo:table-column column-width="18%" column-number="1"/>
+         <fo:table-column column-width="82%" column-number="2"/>
+         <fo:table-body>
+            <fo:table-row>
+               <fo:table-cell border-right-style="solid" border-right-color="blue" padding-right="2em">
+                  <xsl:apply-templates select="rfcnum"/>
+               </fo:table-cell>
+               <fo:table-cell border-right-style="solid" border-right-color="blue" padding-left="1em">
+                  <xsl:apply-templates select="rfctext"/>
+               </fo:table-cell>
+            </fo:table-row>
+         </fo:table-body>
+      </fo:table>
+   </xsl:template>
+   
+   <xsl:template match="*[contains(@class,' oasis/rfcnum ')]">
+      <fo:block>
+         <fo:inline>
+            <xsl:apply-templates/>
+         </fo:inline>
+      </fo:block>
+   </xsl:template>
+   
+   <xsl:template match="*[contains(@class,' oasis/rfctext ')]">
+      <fo:block>
          <xsl:apply-templates/>
       </fo:block>
    </xsl:template>


### PR DESCRIPTION
* For conformance clauses in the running text, display the conformance number to the left of the clause for both HTML and PDF
* The number itself should link directly to that item in the aggregated appendix, and the appendix should link back
* Copy (and update) the CSS from the obsolete XHTML plugin into the HTML5 plugin, and use the HTML5 copy

As a result, we get matching conformance clause style in both PDF and HTML5. The conformance clause itself displays much like it did before this update for PDF, except that the blue border to the left of the clause is indented to make room for the conformance number.

The prefix for the number itself is set in the Ant XML build file with the parameter `rfc.conformance.prefix` so it's pretty easy to try out new prefixes; I expect we will probably want to change from the initial draft here.