### PR TITLE
Limit RFC collection to spec

### DIFF
--- a/org.oasis-open.pdf/build-oasis-pdf.xml
+++ b/org.oasis-open.pdf/build-oasis-pdf.xml
@@ -12,7 +12,7 @@
     
     <!-- Define a common dita2pdf2 for OASIS, which uses the custom preprocess
         in order to pick up topic numbering for TOC / Titles. -->
-    <target name="dita2pdf2.oasis" depends="oasis.specification.init, dita2pdf2.init, build-init, preprocess2.oasis, map2pdf2, topic2pdf2"/>
+    <target name="dita2pdf2.oasis" depends="dita2pdf2.init, build-init, preprocess2.oasis, map2pdf2, topic2pdf2"/>
  
     <!-- Build OASIS committee note -->
     <target name="dita2oasis-pdf-committeeNote" depends="pdf-committeeNote-init, dita2pdf2.oasis"/>
@@ -27,7 +27,7 @@
     </target>
   
     <!-- Build OASIS specification -->
-    <target name="dita2oasis-pdf-specification" depends="pdf-spec-init, dita2pdf2.oasis"/>
+    <target name="dita2oasis-pdf-specification" depends="oasis.specification.init, pdf-spec-init, dita2pdf2.oasis"/>
         
     <target name="pdf-spec-init">
         <property name="customization.dir" 


### PR DESCRIPTION
Signed-off-by: Robert D. Anderson <robert.dan.anderson@oracle.com>

When building OASIS committee note, do not try to build the aggregated RFC list.