### PR TITLE
Simplify RFC numbering

### DIFF
--- a/org.oasis-open.dita.publishing/oasis-common-build_template.xml
+++ b/org.oasis-open.dita.publishing/oasis-common-build_template.xml
@@ -79,7 +79,7 @@
 			</not>
 		</condition>
 		
-		<property name="rfc.conformance.prefix" value="DITA.CONF."/>
+		<property name="rfc.conformance.prefix" value=""/>
 		<property name="tempfile.with.rfc.file" value="${dita.temp.dir}/rfcfile.txt"/>
 		<makeurl property="store.dita.rfc.filename" file="${tempfile.with.rfc.file}" validate="no"/>
 		<property name="rfclist.file" value="${dita.temp.dir}/rfclist.xml"/>

--- a/org.oasis-open.dita.publishing/pdf/fo/xsl/oasis-spec-custom-xsl.xsl
+++ b/org.oasis-open.dita.publishing/pdf/fo/xsl/oasis-spec-custom-xsl.xsl
@@ -54,5 +54,40 @@
          <xsl:apply-templates/>
       </fo:block>
    </xsl:template>
+   
+   <!-- Matches default simpletable, but with override to support default 10/90 column widths.
+   Also removed some bits that do not apply to this table, like checking for missing rows. -->
+   <xsl:template match="*[contains(@class, ' topic/simpletable ')][@outputclass='collected-rfc-rules']">
+      <xsl:variable name="number-cells" as="xs:integer">
+         <!-- Contains the number of cells in the widest row -->
+         <xsl:apply-templates select="*[1]" mode="count-max-simpletable-cells"/>
+      </xsl:variable>
+      <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+      <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
+      <fo:table xsl:use-attribute-sets="simpletable">
+         <xsl:call-template name="commonattributes"/>
+         <xsl:call-template name="globalAtts"/>
+         <xsl:call-template name="displayAtts">
+            <xsl:with-param name="element" select="."/>
+         </xsl:call-template>
+         
+         <!-- Create FOP compatible column widths -->
+         <fo:table-column column-width="10%" column-number="1"/>
+         <fo:table-column column-width="90%" column-number="2"/>
+         
+         <!-- Toss processing to another template to process the simpletable
+                 heading, and/or create a default table heading row. -->
+         <xsl:apply-templates select="*[contains(@class, ' topic/sthead ')]">
+            <xsl:with-param name="number-cells" select="$number-cells" tunnel="yes"/>
+         </xsl:apply-templates>
+         
+         <fo:table-body xsl:use-attribute-sets="simpletable__body">
+            <xsl:apply-templates select="*[contains(@class, ' topic/strow ')]">
+               <xsl:with-param name="number-cells" select="$number-cells" tunnel="yes"/>
+            </xsl:apply-templates>
+         </fo:table-body>
+      </fo:table>
+      <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+   </xsl:template>
 
 </xsl:stylesheet>

--- a/org.oasis-open.dita.publishing/xsl/generate-rfclist.xsl
+++ b/org.oasis-open.dita.publishing/xsl/generate-rfclist.xsl
@@ -61,7 +61,7 @@
         scope="local" href="{concat($dotdots, $rfclist.dita.topic, '/', $rfcnum)}"
         xtrc="{@xtrc}" xtrf="{@xtrf}">
           <xsl:value-of select="$rfcnum"/>
-        <desc class="- topic/desc ">Conformance clause number <xsl:value-of select="$rfcnum"/></desc>
+        <desc class="- topic/desc ">Conformance item <xsl:value-of select="$rfcnum"/></desc>
       </xref>
     </xsl:variable>
     <xsl:choose>
@@ -107,7 +107,7 @@
     <xsl:param name="xtrf"/>
     <xsl:param name="xtrc"/>
     <xsl:if test="rfcitem">
-      <simpletable relcolwidth="1* 7*" class="- topic/simpletable " outputclass="collected-rfc-rules" id="collected-rfc-rules-as-table" frame="all">
+      <simpletable relcolwidth="1* 9*" class="- topic/simpletable " outputclass="collected-rfc-rules" id="collected-rfc-rules-as-table" frame="all">
         <sthead class="- topic/sthead ">
           <stentry class="- topic/stentry " dita-ot:y="1" dita-ot:x="1">Item</stentry>
           <stentry class="- topic/stentry " dita-ot:y="1" dita-ot:x="2">Conformance statement</stentry>
@@ -134,6 +134,7 @@
                 xtrf="{$xtrf}"
                 xtrc="{$xtrc}">
                   <xsl:value-of select="@rfcid"/>
+                <desc class="- topic/desc ">Conformance item <xsl:value-of select="@rfcid"/></desc>
               </xref>
             </stentry>
             <stentry class="- topic/stentry " dita-ot:y="{$rownum}" dita-ot:x="2">

--- a/org.oasis-open.dita.publishing/xslhtml5/format-rfc.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/format-rfc.xsl
@@ -8,16 +8,16 @@
     <table role="presentation" class="rfctable">
       <xsl:call-template name="setid"/>
       <colgroup>
-        <col width="15%"/>
-        <col width="85%"/>
+        <col width="10%"/>
+        <col width="90%"/>
       </colgroup>
       <tbody>
         <tr>
           <td class="rfcnum">
-            <xsl:apply-templates select="rfcnum/node()"/>
+            <xsl:apply-templates select="rfcnum"/>
           </td>
           <td class="rfctext">
-            <xsl:apply-templates select="rfctext/node()"/>
+            <xsl:apply-templates select="rfctext"/>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Changes the numbered / linked clauses from the rather long `DITA.CONF.123` to just the number, `123`. Numbers look a bit better, and allows for a lot more room on the page for the actual clause.

Also updates PDF to explicitly look for this table and make sure the relative column width comes out as 10/90 with FOP.