### PR TITLE
Fix footnote links in spec PDF

### DIFF
--- a/org.oasis-open.dita.publishing/pdf/fo/xsl/oasis-common-links.xsl
+++ b/org.oasis-open.dita.publishing/pdf/fo/xsl/oasis-common-links.xsl
@@ -15,7 +15,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   exclude-result-prefixes="ditaarch opentopic spdf dita-ot opentopic-mapmerge opentopic-func related-links xs">
 
-  <xsl:template match="*[contains(@class, ' topic/xref ')]" name="topic.xref">
+  <xsl:template match="*[contains(@class, ' topic/xref ')][not(@type='fn')]" name="topic.xref">
     <fo:inline>
       <xsl:call-template name="commonattributes"/>
     </fo:inline>


### PR DESCRIPTION
Footnote links in the PDF currently come out with link text "Foot note." rather than the footnote number; this fixes the issue.