### PR TITLE
Fix indent for link short descriptions

### DIFF
--- a/org.oasis-open.dita.publishing/pdf/fo/attrs/oasis-common-links-attr.xsl
+++ b/org.oasis-open.dita.publishing/pdf/fo/attrs/oasis-common-links-attr.xsl
@@ -3,6 +3,7 @@
 <!-- ===================== CHANGE LOG ================================ -->
 <!--                                                                   -->
 <!-- 15 May 2019 KJE: Initial creation                                 -->
+<!-- 08 Nov 2021 RDA: Override link__shortdesc                         -->
 <!--                                                                   -->
 <!-- ================================================================= -->
 
@@ -27,6 +28,13 @@
   <xsl:attribute-set name="link">
     <!--<xsl:attribute name="color">red</xsl:attribute>-->
     <!--<xsl:attribute name="margin-left">20pt</xsl:atribute>-->
+  </xsl:attribute-set>
+  
+  <!-- Override link shortdesc so that start indent is inherited from
+       active indent for related links, rather than getting a new indent -->
+  <xsl:attribute-set name="link__shortdesc">
+    <xsl:attribute name="start-indent">inherit</xsl:attribute>
+    <xsl:attribute name="space-after">5pt</xsl:attribute>
   </xsl:attribute-set>
 
 </xsl:stylesheet>

--- a/org.oasis-open.dita.publishing/pdf/fo/xsl/oasis-common-commons.xsl
+++ b/org.oasis-open.dita.publishing/pdf/fo/xsl/oasis-common-commons.xsl
@@ -7,6 +7,7 @@
 <!-- 21 Jun 2015  BT: Added additional override for chapter titles,    -->
 <!--                  needed for more recent versions of DITA-OT.      -->
 <!-- 16 Aug 2015 KJE: Added additional override for appendix titles.   -->
+<!-- 08 Nov 2021 RDA: override indent, font size for link desc.        -->
 <!--                                                                   -->
 <!-- ================================================================= --> 
 
@@ -20,6 +21,15 @@
                 xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
                 exclude-result-prefixes="ot-placeholder opentopic opentopic-index opentopic-func dita2xslfo xs"
                 version="2.0">
+    
+    <xsl:template match="fo:block/@start-indent|fo:block/@font-size" mode="dropCopiedIds">
+        <!-- start indent, font size get copied from <shortdesc> processing into
+      link description processing. Drop them and use settings from link__shortdesc.
+        
+        This processing comes from commons.xsl (thru topic.xsl) so override is here,
+        rather than in link module that actually processes topic/link + 
+        topic/desc + topic/shortdesc -->
+    </xsl:template>
 
     <!-- OVERRIDE FOR DRAFT COMMENTS -->
     


### PR DESCRIPTION
Fixes indentation for descriptions that follow a link in the related-links section of a topic; with this, the short description indentation matches the link text / related link heading.