### PR TITLE
Fix links in HTML5

### DIFF
--- a/org.oasis-open.dita.publishing/oasis-common-build_template.xml
+++ b/org.oasis-open.dita.publishing/oasis-common-build_template.xml
@@ -216,7 +216,7 @@
 		<!-- Adding "oasislinks" as a link type ensures our custom
       next/previous links only end up affecting the OASIS html output.
       The maplink XSL is in there for other builds but does nothing. -->
-		<property name="include.rellinks" value="friend next previous oasislinks"/>
+		<property name="include.rellinks" value="parent child friend next previous oasislinks"/>
 		<property name="args.copycss" value="yes"/>
 		<property name="args.cssroot"
 			value="${dita.plugin.org.oasis-open.dita.publishing.dir}${file.separator}resources"/>

--- a/org.oasis-open.dita.publishing/xsl/maplink_oasis.xsl
+++ b/org.oasis-open.dita.publishing/xsl/maplink_oasis.xsl
@@ -15,7 +15,13 @@
   <xsl:template match="*[contains(@class, ' map/topicref ')]" mode="link-from">
     <xsl:choose>
       <xsl:when test="$include.roles = 'oasislinks'">
+        <xsl:if test="$include.roles = 'parent'">
+          <xsl:apply-templates select="." mode="link-to-parent"/>
+        </xsl:if>
         <xsl:apply-templates select="." mode="link-to-oasis-next-prev"/>
+        <xsl:if test="$include.roles = 'child'">
+          <xsl:apply-templates select="." mode="link-to-children"/>
+        </xsl:if>
       </xsl:when>
       <xsl:otherwise>
         <xsl:next-match/>
@@ -34,6 +40,10 @@
     <xsl:choose>
       <xsl:when test="preceding-sibling::*[contains(@class,' map/topicref ')][@href]">
         <xsl:apply-templates select="preceding-sibling::*[contains(@class,' map/topicref ')][@href][1]" mode="find-previous-oasis-link"/>
+      </xsl:when>
+      <xsl:when test="contains(@class,' bookmap/chapter ') or contains(@class,' bookmap/appendix ')">
+        <!-- Should only fire with first chapter, which does not have preceding siblings;
+          do not go up to map and then back down -->
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates select="parent::*" mode="link">

--- a/org.oasis-open.dita.publishing/xslhtml5/oasis_coverpage.xsl
+++ b/org.oasis-open.dita.publishing/xslhtml5/oasis_coverpage.xsl
@@ -80,9 +80,9 @@
         <xsl:value-of select="$newline"/>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <xsl:value-of select="$newline"/>
-        <meta content="Copyright © OASIS Open 2012" name="copyright"/>
+        <meta content="Copyright © OASIS Open 2022" name="copyright"/>
         <xsl:value-of select="$newline"/>
-        <meta content=" Copyright © OASIS 2012" name="DC.rights.owner"/>
+        <meta content=" Copyright © OASIS 2022" name="DC.rights.owner"/>
         <xsl:value-of select="$newline"/>
         <!-- KJE 18 August 2022: Commented out OASIS Template CSS -->
         <!--<link href="https://docs.oasis-open.org/templates/css/OASIS_Specification_Template_v1-0.css"


### PR DESCRIPTION
Fixes links, previously had many extra links in the first topic of the first chapter, and previously had lost parent/child links.

Also updates the copyright date on the coverpage from 2012 to 2022.